### PR TITLE
inherit pod encoding for built-in functions

### DIFF
--- a/lib/PJP/M/BuiltinFunction.pm
+++ b/lib/PJP/M/BuiltinFunction.pm
@@ -60,7 +60,7 @@ sub generate {
             my @_candidate;
             open my $fh, '<', $path or die "Cannot open $path: $!";
             while (<$fh>) {
-                $_encoding = $1 and next if m{^=encoding\s+(.+)$};
+                $_encoding = $1 and next if !defined $_encoding && m{^=encoding\s+(.+)$};
                 my @names = m{C<(.*?)>}g;;
                 push @_candidate, map {s{^(tr|s|q|qq|y|m|qr|qx)/+$}{$1}; $_} @names
             }

--- a/lib/PJP/M/BuiltinFunction.pm
+++ b/lib/PJP/M/BuiltinFunction.pm
@@ -67,7 +67,7 @@ sub generate {
             close $fh;
             my %tmp;
             @tmp{@_candidate} = ();
-            keys %tmp;
+            ($_encoding, keys %tmp);
         };
     $encoding ||= 'euc-jp';
 


### PR DESCRIPTION
@ktat perlfuncをもとに各関数の翻訳を切り出していたものが文字化けしてしまった（#4）のでその修正案です。
具体的には ＠argrath さんがpodの翻訳のエンコーディングをUTF-8に変えたのですが、その際にどうもこのあたりでeuc-jpに決め打ちしているために文字化けを起こしてしまっていたようでした。

ローカル環境がうまく作れず検証ができていないのですが、ご確認いただけますでしょうか。