### PR TITLE
rename sourceforge => osdn

### DIFF
--- a/tmpl/about.tt
+++ b/tmpl/about.tt
@@ -15,11 +15,11 @@ miyagawaさんが最初に始めたものを tokuhiromさんが引き継ぎ、�
 </p>
 <h2>Japanized Perl Resources Project</h2>
 <ul>
-    <li><a href="http://perldocjp.sourceforge.jp/">ホームページ</a>
-    <li><a href="http://sourceforge.jp/projects/perldocjp/">sourceforge.jp のプロジェクトページ</a></li>
+    <li><a href="https://perldocjp.osdn.jp/">ホームページ</a>
+    <li><a href="https://osdn.net/projects/perldocjp/">OSDN のプロジェクトページ</a></li>
 </ul>
 <p>
-参加方法はホームページからたどれます。sourceforge.jpのアカウントが必要になります。
+参加方法はホームページからたどれます。OSDNのアカウントが必要になります。
 </p>
 <h2>git リポジトリ(github)</h2>
 <ul>
@@ -43,7 +43,7 @@ miyagawaさんが最初に始めたものを tokuhiromさんが引き継ぎ、�
 以下から報告できます。翻訳者の連絡先がある場合は、そちらにメールしても良いかも知れません。
 </p>
 <ul>
-<li><a href="http://sourceforge.jp/projects/perldocjp/ticket/?type%5B%5D=589&type_mode%5B%5D=eq&status%5B%5D=1">JPRPの誤訳の報告</a></li>
+<li><a href="https://osdn.net/projects/perldocjp/ticket/">JPRPの誤訳の報告</a></li>
 <li><a href="https://github.com/perldoc-jp/module-pod-jp/issues">gitリポジトリの誤訳の報告</a></li>
 <li><a href="https://github.com/jpa-perl/perldoc.jp/issues">サイトの不具合の報告</a></li>
 </ul>

--- a/tmpl/layout.html
+++ b/tmpl/layout.html
@@ -74,7 +74,7 @@
             <div id="content">[% content %]</div>
         </div>
         <div class="footer span-24 last">
-            Powered by Amon2, <a href="http://sourceforge.jp/projects/perldocjp/">perldocjp project</a>. Operated by <a href="http://japan.perlassociation.org">Japan Perl Association</a>
+            Powered by Amon2, <a href="https://osdn.net/projects/perldocjp/">perldocjp project</a>. Operated by <a href="http://japan.perlassociation.org">Japan Perl Association</a>
         </div>
     </div>
 </body>

--- a/tmpl/manners.tt
+++ b/tmpl/manners.tt
@@ -417,7 +417,7 @@ JPRP、gitリポジトリで翻訳された場合は、当サイトのRSSフィ�
 JPRPに関する個別の決め事などは、以下を参照してください。
 </p>
 <ul>
-<li><a href="http://perldocjp.sourceforge.jp/perldocjp-faq">FAQ</a></li>
-<li><a href="http://sourceforge.jp/projects/perldocjp/docman/">その他文書</a></li>
+<li><a href="http://perldocjp.osdn.jp/perldocjp-faq">FAQ</a></li>
+<li><a href="http://osdn.net/projects/perldocjp/docman/">その他文書</a></li>
 </ul>
 [% END %]

--- a/tmpl/pod.tt
+++ b/tmpl/pod.tt
@@ -49,8 +49,8 @@
             <div><a target="_blank" href="https://github.com/jpa/Moose-Doc-JA/commits/master/[% github_path %]">変更履歴(github)</a></div>
             <div><a target="_blank" href="https://github.com/jpa/Moose-Doc-JA/issues/new?title=[% distvname | url %][% "の誤訳の報告" | url %]">誤訳の報告</a></div>
             [% ELSE %]
-            <div><a target="_blank"  href="http://sourceforge.jp/cvs/view/perldocjp/docs/[% path %]?view=log">変更履歴(sf.jp)</a></div>
-            <div><a target="_blank" href="http://sourceforge.jp/ticket/newticket.php?group_id=136">誤訳の報告</a></div>
+            <div><a target="_blank"  href="https://osdn.net/cvs/view/perldocjp/docs/[% path %]?view=log">変更履歴(sf.jp)</a></div>
+            <div><a target="_blank" href="https://osdn.net/ticket/newticket.php?group_id=136">誤訳の報告</a></div>
             [% END %]
             [% IF has_original %]
             <script>


### PR DESCRIPTION
サイト上で、sourcefoge となっていたものを、osdn にURLを変更しました。