### PR TITLE
obsolute GET /category

### DIFF
--- a/lib/PJP/Web/Dispatcher.pm
+++ b/lib/PJP/Web/Dispatcher.pm
@@ -42,15 +42,15 @@ get '/translators' => sub {
     return $c->render('translators.tt', {years => do 'data/years.pl'});
 };
 
-get '/category' => sub {
-    my $c = shift;
-
-    return $c->render('category.tt', {
-                                   en2ja               => do "data/category_en2ja.pl",
-                                   categorized_modules => do "data/category_data.pl",
-                                  });
-};
-
+# NOTE: 2021/12/27: search.cpan.orgからmetacpan.orgへの移行に伴い意味不明な分類になっていたので廃止
+# get '/category' => sub {
+#     my $c = shift;
+#
+#     return $c->render('category.tt', {
+#                                    en2ja               => do "data/category_en2ja.pl",
+#                                    categorized_modules => do "data/category_data.pl",
+#                                   });
+# };
 
 get '/category/:name' => sub {
     my ($c, $args) = @_;

--- a/tmpl/layout.html
+++ b/tmpl/layout.html
@@ -51,7 +51,7 @@
             <li><a href="/index/function">関数</a></li>
             <li><a href="/index/variable">変数</a></li>
             <li><a href="/index/module">モジュール</a></li>
-            <li><a href="/category">カテゴリ別</a></li>
+            <!--li><a href="/category">カテゴリ別</a></li-->
             <li><a href="/index/article">その他の翻訳</a></li>
             <li><a href="/translators">翻訳者</a></li>
             <li><a href="/manners">翻訳の作法</a></li>


### PR DESCRIPTION
search.cpan.orgからmetacpan.orgへの移行に伴い `/category` 意味不明な分類になってしまってもはや意味をなしていないので2021/12/27から廃止しています