### PR TITLE
微調整

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,10 @@ Entries.Log
 nytprof/
 db/
 *.sw[pomn]
+
+/.carmel/
+/local/
+/data/recent.pl
+/data/years.pl
+/static/docs.json
+/static/rss/

--- a/cpanfile.snapshot
+++ b/cpanfile.snapshot
@@ -1,0 +1,3467 @@
+# carton snapshot format: version 1.0
+DISTRIBUTIONS
+  Algorithm-Diff-1.201
+    pathname: R/RJ/RJBS/Algorithm-Diff-1.201.tar.gz
+    provides:
+      Algorithm::Diff 1.201
+      Algorithm::Diff::_impl 1.201
+    requirements:
+      ExtUtils::MakeMaker 0
+  Amon2-6.15
+    pathname: T/TO/TOKUHIROM/Amon2-6.15.tar.gz
+    provides:
+      Amon2 6.15
+      Amon2::Config::Simple undef
+      Amon2::ContextGuard undef
+      Amon2::Declare undef
+      Amon2::Plugin::Web::FillInFormLite undef
+      Amon2::Plugin::Web::JSON undef
+      Amon2::Plugin::Web::NoCache undef
+      Amon2::Plugin::Web::PlackSession undef
+      Amon2::Plugin::Web::Streaming undef
+      Amon2::Plugin::Web::WebSocket undef
+      Amon2::Setup::Asset::Blueprint undef
+      Amon2::Setup::Asset::Bootstrap undef
+      Amon2::Setup::Asset::ES5Shim undef
+      Amon2::Setup::Asset::MicroDispatcherJS undef
+      Amon2::Setup::Asset::MicroLocationJS undef
+      Amon2::Setup::Asset::MicroTemplateJS undef
+      Amon2::Setup::Asset::SprintfJS undef
+      Amon2::Setup::Asset::StrftimeJS undef
+      Amon2::Setup::Asset::XSRFTokenJS undef
+      Amon2::Setup::Asset::jQuery undef
+      Amon2::Setup::Flavor undef
+      Amon2::Setup::Flavor::Basic 6.15
+      Amon2::Setup::Flavor::Large 6.15
+      Amon2::Setup::Flavor::Minimum 6.15
+      Amon2::Setup::VC::Git undef
+      Amon2::Trigger undef
+      Amon2::Util undef
+      Amon2::Web undef
+      Amon2::Web::Dispatcher::Lite undef
+      Amon2::Web::Dispatcher::RouterBoom undef
+      Amon2::Web::Dispatcher::RouterSimple undef
+      Amon2::Web::Request undef
+      Amon2::Web::Response undef
+      Amon2::Web::Response::Callback undef
+      Amon2::Web::WebSocket undef
+    requirements:
+      Digest::SHA 0
+      Encode 0
+      Exporter 0
+      File::Copy::Recursive 0
+      File::ShareDir 0
+      File::Temp 0
+      Getopt::Long 0
+      HTML::FillInForm::Lite 0
+      HTTP::Headers 0
+      HTTP::Session2 0
+      Hash::MultiValue 0
+      JSON 2
+      MIME::Base64 0
+      Module::Build::Tiny 0.035
+      Module::CPANfile 0.9020
+      Plack 0.9982
+      Plack::Request 0
+      Plack::Response 0
+      Plack::Session 0
+      Plack::Util 0
+      Pod::Usage 0
+      Router::Boom 0.07
+      Scalar::Util 0
+      Text::Xslate 2.0010
+      Time::HiRes 0
+      Try::Tiny 0.06
+      URI 1.54
+      URI::Escape 0
+      URI::QueryParam 0
+      mro 0
+      parent 0.223
+      perl 5.010000
+  Apache-LogFormat-Compiler-0.36
+    pathname: K/KA/KAZEBURO/Apache-LogFormat-Compiler-0.36.tar.gz
+    provides:
+      Apache::LogFormat::Compiler 0.36
+    requirements:
+      Module::Build::Tiny 0.035
+      POSIX 0
+      POSIX::strftime::Compiler 0.30
+      Time::Local 0
+      perl 5.008001
+  B-Hooks-EndOfScope-0.25
+    pathname: E/ET/ETHER/B-Hooks-EndOfScope-0.25.tar.gz
+    provides:
+      B::Hooks::EndOfScope 0.25
+      B::Hooks::EndOfScope::PP 0.25
+      B::Hooks::EndOfScope::XS 0.25
+    requirements:
+      ExtUtils::MakeMaker 0
+      Hash::Util::FieldHash 0
+      Module::Implementation 0.05
+      Scalar::Util 0
+      Sub::Exporter::Progressive 0.001006
+      Text::ParseWords 0
+      Tie::Hash 0
+      Variable::Magic 0.48
+      perl 5.006001
+      strict 0
+      warnings 0
+  B-Hooks-OP-Check-0.22
+    pathname: E/ET/ETHER/B-Hooks-OP-Check-0.22.tar.gz
+    provides:
+      B::Hooks::OP::Check 0.22
+    requirements:
+      DynaLoader 0
+      ExtUtils::Depends 0.302
+      ExtUtils::MakeMaker 0
+      parent 0
+      perl 5.008001
+      strict 0
+      warnings 0
+  CPAN-DistnameInfo-0.12
+    pathname: G/GB/GBARR/CPAN-DistnameInfo-0.12.tar.gz
+    provides:
+      CPAN::DistnameInfo 0.12
+    requirements:
+      ExtUtils::MakeMaker 0
+      Test::More 0
+  CPAN-Meta-2.150010
+    pathname: D/DA/DAGOLDEN/CPAN-Meta-2.150010.tar.gz
+    provides:
+      CPAN::Meta 2.150010
+      CPAN::Meta::Converter 2.150010
+      CPAN::Meta::Feature 2.150010
+      CPAN::Meta::History 2.150010
+      CPAN::Meta::Merge 2.150010
+      CPAN::Meta::Prereqs 2.150010
+      CPAN::Meta::Spec 2.150010
+      CPAN::Meta::Validator 2.150010
+      Parse::CPAN::Meta 2.150010
+    requirements:
+      CPAN::Meta::Requirements 2.121
+      CPAN::Meta::YAML 0.011
+      Carp 0
+      Encode 0
+      Exporter 0
+      ExtUtils::MakeMaker 6.17
+      File::Spec 0.80
+      JSON::PP 2.27300
+      Scalar::Util 0
+      perl 5.008001
+      strict 0
+      version 0.88
+      warnings 0
+  CPAN-Meta-YAML-0.018
+    pathname: D/DA/DAGOLDEN/CPAN-Meta-YAML-0.018.tar.gz
+    provides:
+      CPAN::Meta::YAML 0.018
+    requirements:
+      B 0
+      Carp 0
+      Exporter 0
+      ExtUtils::MakeMaker 6.17
+      Fcntl 0
+      Scalar::Util 0
+      perl 5.008001
+      strict 0
+      warnings 0
+  Cache-Cache-1.08
+    pathname: R/RJ/RJBS/Cache-Cache-1.08.tar.gz
+    provides:
+      Cache::BaseCache undef
+      Cache::BaseCacheTester undef
+      Cache::Cache 1.08
+      Cache::CacheMetaData undef
+      Cache::CacheSizer undef
+      Cache::CacheTester undef
+      Cache::CacheUtils undef
+      Cache::FileBackend undef
+      Cache::FileCache undef
+      Cache::MemoryBackend undef
+      Cache::MemoryCache undef
+      Cache::NullCache undef
+      Cache::Object undef
+      Cache::SharedMemoryBackend undef
+      Cache::SharedMemoryCache undef
+      Cache::SizeAwareCache undef
+      Cache::SizeAwareCacheTester undef
+      Cache::SizeAwareFileCache undef
+      Cache::SizeAwareMemoryCache undef
+      Cache::SizeAwareSharedMemoryCache undef
+    requirements:
+      Digest::SHA1 2.02
+      Error 0.15
+      ExtUtils::MakeMaker 0
+      File::Spec 0.82
+      Storable 1.014
+  Canary-Stability-2013
+    pathname: M/ML/MLEHMANN/Canary-Stability-2013.tar.gz
+    provides:
+      Canary::Stability 2013
+    requirements:
+      ExtUtils::MakeMaker 0
+  Capture-Tiny-0.48
+    pathname: D/DA/DAGOLDEN/Capture-Tiny-0.48.tar.gz
+    provides:
+      Capture::Tiny 0.48
+    requirements:
+      Carp 0
+      Exporter 0
+      ExtUtils::MakeMaker 6.17
+      File::Spec 0
+      File::Temp 0
+      IO::Handle 0
+      Scalar::Util 0
+      perl 5.006
+      strict 0
+      warnings 0
+  Carp-Clan-6.08
+    pathname: E/ET/ETHER/Carp-Clan-6.08.tar.gz
+    provides:
+      Carp::Clan 6.08
+    requirements:
+      ExtUtils::MakeMaker 0
+      overload 0
+      perl 5.006
+      strict 0
+  Class-Accessor-Lite-0.08
+    pathname: K/KA/KAZUHO/Class-Accessor-Lite-0.08.tar.gz
+    provides:
+      Class::Accessor::Lite 0.08
+    requirements:
+      ExtUtils::MakeMaker 6.36
+  Class-Data-Inheritable-0.09
+    pathname: R/RS/RSHERER/Class-Data-Inheritable-0.09.tar.gz
+    provides:
+      Class::Data::Inheritable 0.09
+    requirements:
+      ExtUtils::MakeMaker 0
+  Class-Inspector-1.36
+    pathname: P/PL/PLICEASE/Class-Inspector-1.36.tar.gz
+    provides:
+      Class::Inspector 1.36
+      Class::Inspector::Functions 1.36
+    requirements:
+      ExtUtils::MakeMaker 0
+      File::Spec 0.80
+      base 0
+      perl 5.008
+  Class-Method-Modifiers-2.13
+    pathname: E/ET/ETHER/Class-Method-Modifiers-2.13.tar.gz
+    provides:
+      Class::Method::Modifiers 2.13
+    requirements:
+      B 0
+      Carp 0
+      Exporter 0
+      ExtUtils::MakeMaker 0
+      base 0
+      perl 5.006
+      strict 0
+      warnings 0
+  Class-Singleton-1.6
+    pathname: S/SH/SHAY/Class-Singleton-1.6.tar.gz
+    provides:
+      Class::Singleton 1.6
+    requirements:
+      ExtUtils::MakeMaker 6.64
+      perl 5.008001
+      strict 0
+      warnings 0
+  Cookie-Baker-0.11
+    pathname: K/KA/KAZEBURO/Cookie-Baker-0.11.tar.gz
+    provides:
+      Cookie::Baker 0.11
+    requirements:
+      Exporter 0
+      Module::Build::Tiny 0.035
+      URI::Escape 0
+      perl 5.008001
+  Cpanel-JSON-XS-4.27
+    pathname: R/RU/RURBAN/Cpanel-JSON-XS-4.27.tar.gz
+    provides:
+      Cpanel::JSON::XS 4.27
+      Cpanel::JSON::XS::Type undef
+    requirements:
+      Carp 0
+      Config 0
+      Encode 1.9801
+      Exporter 0
+      ExtUtils::MakeMaker 0
+      Pod::Text 2.08
+      XSLoader 0
+      overload 0
+      strict 0
+      warnings 0
+  Crypt-CBC-3.04
+    pathname: L/LD/LDS/Crypt-CBC-3.04.tar.gz
+    provides:
+      Crypt::CBC 3.04
+      Crypt::CBC::PBKDF undef
+      Crypt::CBC::PBKDF::none undef
+      Crypt::CBC::PBKDF::opensslv1 undef
+      Crypt::CBC::PBKDF::opensslv2 undef
+      Crypt::CBC::PBKDF::pbkdf2 undef
+      Crypt::CBC::PBKDF::randomiv undef
+    requirements:
+      Crypt::Cipher::AES 0
+      Crypt::PBKDF2 0
+      Digest::MD5 0
+      Digest::SHA 0
+      ExtUtils::MakeMaker 0
+  Crypt-PBKDF2-0.161520
+    pathname: A/AR/ARODLAND/Crypt-PBKDF2-0.161520.tar.gz
+    provides:
+      Crypt::PBKDF2 0.161520
+      Crypt::PBKDF2::Hash 0.161520
+      Crypt::PBKDF2::Hash::DigestHMAC 0.161520
+      Crypt::PBKDF2::Hash::HMACSHA1 0.161520
+      Crypt::PBKDF2::Hash::HMACSHA2 0.161520
+      Crypt::PBKDF2::Hash::HMACSHA3 0.161520
+    requirements:
+      Carp 0
+      Digest 1.16
+      Digest::HMAC 1.01
+      Digest::SHA 0
+      Digest::SHA3 0.22
+      ExtUtils::MakeMaker 0
+      MIME::Base64 0
+      Module::Runtime 0
+      Moo 2
+      Moo::Role 2
+      Scalar::Util 0
+      Try::Tiny 0.04
+      Type::Tiny 0
+      Types::Standard 1.000005
+      namespace::autoclean 0
+      strictures 2
+  CryptX-0.075
+    pathname: M/MI/MIK/CryptX-0.075.tar.gz
+    provides:
+      Crypt::AuthEnc 0.075
+      Crypt::AuthEnc::CCM 0.075
+      Crypt::AuthEnc::ChaCha20Poly1305 0.075
+      Crypt::AuthEnc::EAX 0.075
+      Crypt::AuthEnc::GCM 0.075
+      Crypt::AuthEnc::OCB 0.075
+      Crypt::Checksum 0.075
+      Crypt::Checksum::Adler32 0.075
+      Crypt::Checksum::CRC32 0.075
+      Crypt::Cipher 0.075
+      Crypt::Cipher::AES 0.075
+      Crypt::Cipher::Anubis 0.075
+      Crypt::Cipher::Blowfish 0.075
+      Crypt::Cipher::CAST5 0.075
+      Crypt::Cipher::Camellia 0.075
+      Crypt::Cipher::DES 0.075
+      Crypt::Cipher::DES_EDE 0.075
+      Crypt::Cipher::IDEA 0.075
+      Crypt::Cipher::KASUMI 0.075
+      Crypt::Cipher::Khazad 0.075
+      Crypt::Cipher::MULTI2 0.075
+      Crypt::Cipher::Noekeon 0.075
+      Crypt::Cipher::RC2 0.075
+      Crypt::Cipher::RC5 0.075
+      Crypt::Cipher::RC6 0.075
+      Crypt::Cipher::SAFERP 0.075
+      Crypt::Cipher::SAFER_K128 0.075
+      Crypt::Cipher::SAFER_K64 0.075
+      Crypt::Cipher::SAFER_SK128 0.075
+      Crypt::Cipher::SAFER_SK64 0.075
+      Crypt::Cipher::SEED 0.075
+      Crypt::Cipher::Serpent 0.075
+      Crypt::Cipher::Skipjack 0.075
+      Crypt::Cipher::Twofish 0.075
+      Crypt::Cipher::XTEA 0.075
+      Crypt::Digest 0.075
+      Crypt::Digest::BLAKE2b_160 0.075
+      Crypt::Digest::BLAKE2b_256 0.075
+      Crypt::Digest::BLAKE2b_384 0.075
+      Crypt::Digest::BLAKE2b_512 0.075
+      Crypt::Digest::BLAKE2s_128 0.075
+      Crypt::Digest::BLAKE2s_160 0.075
+      Crypt::Digest::BLAKE2s_224 0.075
+      Crypt::Digest::BLAKE2s_256 0.075
+      Crypt::Digest::CHAES 0.075
+      Crypt::Digest::Keccak224 0.075
+      Crypt::Digest::Keccak256 0.075
+      Crypt::Digest::Keccak384 0.075
+      Crypt::Digest::Keccak512 0.075
+      Crypt::Digest::MD2 0.075
+      Crypt::Digest::MD4 0.075
+      Crypt::Digest::MD5 0.075
+      Crypt::Digest::RIPEMD128 0.075
+      Crypt::Digest::RIPEMD160 0.075
+      Crypt::Digest::RIPEMD256 0.075
+      Crypt::Digest::RIPEMD320 0.075
+      Crypt::Digest::SHA1 0.075
+      Crypt::Digest::SHA224 0.075
+      Crypt::Digest::SHA256 0.075
+      Crypt::Digest::SHA384 0.075
+      Crypt::Digest::SHA3_224 0.075
+      Crypt::Digest::SHA3_256 0.075
+      Crypt::Digest::SHA3_384 0.075
+      Crypt::Digest::SHA3_512 0.075
+      Crypt::Digest::SHA512 0.075
+      Crypt::Digest::SHA512_224 0.075
+      Crypt::Digest::SHA512_256 0.075
+      Crypt::Digest::SHAKE 0.075
+      Crypt::Digest::Tiger192 0.075
+      Crypt::Digest::Whirlpool 0.075
+      Crypt::KeyDerivation 0.075
+      Crypt::Mac 0.075
+      Crypt::Mac::BLAKE2b 0.075
+      Crypt::Mac::BLAKE2s 0.075
+      Crypt::Mac::F9 0.075
+      Crypt::Mac::HMAC 0.075
+      Crypt::Mac::OMAC 0.075
+      Crypt::Mac::PMAC 0.075
+      Crypt::Mac::Pelican 0.075
+      Crypt::Mac::Poly1305 0.075
+      Crypt::Mac::XCBC 0.075
+      Crypt::Misc 0.075
+      Crypt::Mode 0.075
+      Crypt::Mode::CBC 0.075
+      Crypt::Mode::CFB 0.075
+      Crypt::Mode::CTR 0.075
+      Crypt::Mode::ECB 0.075
+      Crypt::Mode::OFB 0.075
+      Crypt::PK 0.075
+      Crypt::PK::DH 0.075
+      Crypt::PK::DSA 0.075
+      Crypt::PK::ECC 0.075
+      Crypt::PK::Ed25519 0.075
+      Crypt::PK::RSA 0.075
+      Crypt::PK::X25519 0.075
+      Crypt::PRNG 0.075
+      Crypt::PRNG::ChaCha20 0.075
+      Crypt::PRNG::Fortuna 0.075
+      Crypt::PRNG::RC4 0.075
+      Crypt::PRNG::Sober128 0.075
+      Crypt::PRNG::Yarrow 0.075
+      Crypt::Stream::ChaCha 0.075
+      Crypt::Stream::RC4 0.075
+      Crypt::Stream::Rabbit 0.075
+      Crypt::Stream::Salsa20 0.075
+      Crypt::Stream::Sober128 0.075
+      Crypt::Stream::Sosemanuk 0.075
+      CryptX 0.075
+      Math::BigInt::LTM 0.075
+    requirements:
+      ExtUtils::MakeMaker 0
+      Math::BigInt 0
+      perl 5.006
+  DBD-SQLite-1.70
+    pathname: I/IS/ISHIGAKI/DBD-SQLite-1.70.tar.gz
+    provides:
+      DBD::SQLite 1.70
+      DBD::SQLite::Constants undef
+      DBD::SQLite::GetInfo undef
+      DBD::SQLite::VirtualTable 1.70
+      DBD::SQLite::VirtualTable::Cursor 1.70
+      DBD::SQLite::VirtualTable::FileContent undef
+      DBD::SQLite::VirtualTable::FileContent::Cursor undef
+      DBD::SQLite::VirtualTable::PerlData undef
+      DBD::SQLite::VirtualTable::PerlData::Cursor undef
+    requirements:
+      DBI 1.57
+      ExtUtils::MakeMaker 0
+      File::Spec 0.82
+      Test::More 0.88
+      Tie::Hash 0
+      perl 5.006
+  DBI-1.643
+    pathname: T/TI/TIMB/DBI-1.643.tar.gz
+    provides:
+      Bundle::DBI 12.008696
+      DBD::DBM 0.08
+      DBD::DBM::Statement 0.08
+      DBD::DBM::Table 0.08
+      DBD::DBM::db 0.08
+      DBD::DBM::dr 0.08
+      DBD::DBM::st 0.08
+      DBD::ExampleP 12.014311
+      DBD::ExampleP::db 12.014311
+      DBD::ExampleP::dr 12.014311
+      DBD::ExampleP::st 12.014311
+      DBD::File 0.44
+      DBD::File::DataSource::File 0.44
+      DBD::File::DataSource::Stream 0.44
+      DBD::File::Statement 0.44
+      DBD::File::Table 0.44
+      DBD::File::TableSource::FileSystem 0.44
+      DBD::File::db 0.44
+      DBD::File::dr 0.44
+      DBD::File::st 0.44
+      DBD::Gofer 0.015327
+      DBD::Gofer::Policy::Base 0.010088
+      DBD::Gofer::Policy::classic 0.010088
+      DBD::Gofer::Policy::pedantic 0.010088
+      DBD::Gofer::Policy::rush 0.010088
+      DBD::Gofer::Transport::Base 0.014121
+      DBD::Gofer::Transport::corostream undef
+      DBD::Gofer::Transport::null 0.010088
+      DBD::Gofer::Transport::pipeone 0.010088
+      DBD::Gofer::Transport::stream 0.014599
+      DBD::Gofer::db 0.015327
+      DBD::Gofer::dr 0.015327
+      DBD::Gofer::st 0.015327
+      DBD::Mem 0.001
+      DBD::Mem::DataSource 0.001
+      DBD::Mem::Statement 0.001
+      DBD::Mem::Table 0.001
+      DBD::Mem::db 0.001
+      DBD::Mem::dr 0.001
+      DBD::Mem::st 0.001
+      DBD::NullP 12.014715
+      DBD::NullP::db 12.014715
+      DBD::NullP::dr 12.014715
+      DBD::NullP::st 12.014715
+      DBD::Proxy 0.2004
+      DBD::Proxy::RPC::PlClient 0.2004
+      DBD::Proxy::db 0.2004
+      DBD::Proxy::dr 0.2004
+      DBD::Proxy::st 0.2004
+      DBD::Sponge 12.010003
+      DBD::Sponge::db 12.010003
+      DBD::Sponge::dr 12.010003
+      DBD::Sponge::st 12.010003
+      DBDI 12.015129
+      DBI 1.643
+      DBI::Const::GetInfo::ANSI 2.008697
+      DBI::Const::GetInfo::ODBC 2.011374
+      DBI::Const::GetInfoReturn 2.008697
+      DBI::Const::GetInfoType 2.008697
+      DBI::DBD 12.015129
+      DBI::DBD::Metadata 2.014214
+      DBI::DBD::SqlEngine 0.06
+      DBI::DBD::SqlEngine::DataSource 0.06
+      DBI::DBD::SqlEngine::Statement 0.06
+      DBI::DBD::SqlEngine::Table 0.06
+      DBI::DBD::SqlEngine::TableSource 0.06
+      DBI::DBD::SqlEngine::TieMeta 0.06
+      DBI::DBD::SqlEngine::TieTables 0.06
+      DBI::DBD::SqlEngine::db 0.06
+      DBI::DBD::SqlEngine::dr 0.06
+      DBI::DBD::SqlEngine::st 0.06
+      DBI::Gofer::Execute 0.014283
+      DBI::Gofer::Request 0.012537
+      DBI::Gofer::Response 0.011566
+      DBI::Gofer::Serializer::Base 0.009950
+      DBI::Gofer::Serializer::DataDumper 0.009950
+      DBI::Gofer::Serializer::Storable 0.015586
+      DBI::Gofer::Transport::Base 0.012537
+      DBI::Gofer::Transport::pipeone 0.012537
+      DBI::Gofer::Transport::stream 0.012537
+      DBI::Profile 2.015065
+      DBI::ProfileData 2.010008
+      DBI::ProfileDumper 2.015325
+      DBI::ProfileDumper::Apache 2.014121
+      DBI::ProfileSubs 0.009396
+      DBI::ProxyServer 0.3005
+      DBI::ProxyServer::db 0.3005
+      DBI::ProxyServer::dr 0.3005
+      DBI::ProxyServer::st 0.3005
+      DBI::SQL::Nano 1.015544
+      DBI::SQL::Nano::Statement_ 1.015544
+      DBI::SQL::Nano::Table_ 1.015544
+      DBI::Util::CacheMemory 0.010315
+      DBI::Util::_accessor 0.009479
+      DBI::common 1.643
+    requirements:
+      ExtUtils::MakeMaker 6.48
+      Test::Simple 0.90
+      perl 5.008001
+  DBIx-TransactionManager-1.13
+    pathname: N/NE/NEKOKAK/DBIx-TransactionManager-1.13.tar.gz
+    provides:
+      DBIx::TransactionManager 1.13
+      DBIx::TransactionManager::ScopeGuard 1.13
+    requirements:
+      DBI 0
+      ExtUtils::MakeMaker 6.36
+      Test::More 0.96
+      Try::Tiny 0
+  Data-MessagePack-1.01
+    pathname: S/SY/SYOHEX/Data-MessagePack-1.01.tar.gz
+    provides:
+      Data::MessagePack 1.01
+      Data::MessagePack::Boolean undef
+      Data::MessagePack::PP undef
+    requirements:
+      ExtUtils::CBuilder 0
+      Math::BigInt 1.89
+      Module::Build 0.4005
+      Module::Build::XSUtil 0.19
+      perl 5.008001
+  DateTime-1.55
+    pathname: D/DR/DROLSKY/DateTime-1.55.tar.gz
+    provides:
+      DateTime 1.55
+      DateTime::Duration 1.55
+      DateTime::Helpers 1.55
+      DateTime::Infinite 1.55
+      DateTime::LeapSecond 1.55
+      DateTime::PP 1.55
+      DateTime::PPExtra 1.55
+      DateTime::Types 1.55
+    requirements:
+      Carp 0
+      DateTime::Locale 1.06
+      DateTime::TimeZone 2.44
+      Dist::CheckConflicts 0.02
+      ExtUtils::MakeMaker 0
+      POSIX 0
+      Params::ValidationCompiler 0.26
+      Scalar::Util 0
+      Specio 0.18
+      Specio::Declare 0
+      Specio::Exporter 0
+      Specio::Library::Builtins 0
+      Specio::Library::Numeric 0
+      Specio::Library::String 0
+      Try::Tiny 0
+      XSLoader 0
+      base 0
+      integer 0
+      namespace::autoclean 0.19
+      overload 0
+      parent 0
+      perl 5.008004
+      strict 0
+      warnings 0
+      warnings::register 0
+  DateTime-Format-Mail-0.403
+    pathname: B/BO/BOOK/DateTime-Format-Mail-0.403.tar.gz
+    provides:
+      DateTime::Format::Mail 0.403
+    requirements:
+      Carp 0
+      DateTime 1.04
+      ExtUtils::MakeMaker 0
+      Params::Validate 0
+      perl 5.006
+      strict 0
+      vars 0
+  DateTime-Format-W3CDTF-0.08
+    pathname: G/GW/GWILLIAMS/DateTime-Format-W3CDTF-0.08.tar.gz
+    provides:
+      DateTime::Format::W3CDTF 0.08
+    requirements:
+      DateTime 0
+      ExtUtils::MakeMaker 6.59
+      Test::More 0.61
+      perl 5.008
+  DateTime-Locale-1.33
+    pathname: D/DR/DROLSKY/DateTime-Locale-1.33.tar.gz
+    provides:
+      DateTime::Locale 1.33
+      DateTime::Locale::Base 1.33
+      DateTime::Locale::Catalog 1.33
+      DateTime::Locale::Data 1.33
+      DateTime::Locale::FromData 1.33
+      DateTime::Locale::Util 1.33
+    requirements:
+      Carp 0
+      Dist::CheckConflicts 0.02
+      Exporter 0
+      ExtUtils::MakeMaker 0
+      File::ShareDir 0
+      File::ShareDir::Install 0.06
+      File::Spec 0
+      List::Util 1.45
+      Params::ValidationCompiler 0.13
+      Specio::Declare 0
+      Specio::Library::String 0
+      Storable 0
+      namespace::autoclean 0.19
+      perl 5.008004
+      strict 0
+      warnings 0
+  DateTime-TimeZone-2.51
+    pathname: D/DR/DROLSKY/DateTime-TimeZone-2.51.tar.gz
+    provides:
+      DateTime::TimeZone 2.51
+      DateTime::TimeZone::Africa::Abidjan 2.51
+      DateTime::TimeZone::Africa::Algiers 2.51
+      DateTime::TimeZone::Africa::Bissau 2.51
+      DateTime::TimeZone::Africa::Cairo 2.51
+      DateTime::TimeZone::Africa::Casablanca 2.51
+      DateTime::TimeZone::Africa::Ceuta 2.51
+      DateTime::TimeZone::Africa::El_Aaiun 2.51
+      DateTime::TimeZone::Africa::Johannesburg 2.51
+      DateTime::TimeZone::Africa::Juba 2.51
+      DateTime::TimeZone::Africa::Khartoum 2.51
+      DateTime::TimeZone::Africa::Lagos 2.51
+      DateTime::TimeZone::Africa::Maputo 2.51
+      DateTime::TimeZone::Africa::Monrovia 2.51
+      DateTime::TimeZone::Africa::Nairobi 2.51
+      DateTime::TimeZone::Africa::Ndjamena 2.51
+      DateTime::TimeZone::Africa::Sao_Tome 2.51
+      DateTime::TimeZone::Africa::Tripoli 2.51
+      DateTime::TimeZone::Africa::Tunis 2.51
+      DateTime::TimeZone::Africa::Windhoek 2.51
+      DateTime::TimeZone::America::Adak 2.51
+      DateTime::TimeZone::America::Anchorage 2.51
+      DateTime::TimeZone::America::Araguaina 2.51
+      DateTime::TimeZone::America::Argentina::Buenos_Aires 2.51
+      DateTime::TimeZone::America::Argentina::Catamarca 2.51
+      DateTime::TimeZone::America::Argentina::Cordoba 2.51
+      DateTime::TimeZone::America::Argentina::Jujuy 2.51
+      DateTime::TimeZone::America::Argentina::La_Rioja 2.51
+      DateTime::TimeZone::America::Argentina::Mendoza 2.51
+      DateTime::TimeZone::America::Argentina::Rio_Gallegos 2.51
+      DateTime::TimeZone::America::Argentina::Salta 2.51
+      DateTime::TimeZone::America::Argentina::San_Juan 2.51
+      DateTime::TimeZone::America::Argentina::San_Luis 2.51
+      DateTime::TimeZone::America::Argentina::Tucuman 2.51
+      DateTime::TimeZone::America::Argentina::Ushuaia 2.51
+      DateTime::TimeZone::America::Asuncion 2.51
+      DateTime::TimeZone::America::Bahia 2.51
+      DateTime::TimeZone::America::Bahia_Banderas 2.51
+      DateTime::TimeZone::America::Barbados 2.51
+      DateTime::TimeZone::America::Belem 2.51
+      DateTime::TimeZone::America::Belize 2.51
+      DateTime::TimeZone::America::Boa_Vista 2.51
+      DateTime::TimeZone::America::Bogota 2.51
+      DateTime::TimeZone::America::Boise 2.51
+      DateTime::TimeZone::America::Cambridge_Bay 2.51
+      DateTime::TimeZone::America::Campo_Grande 2.51
+      DateTime::TimeZone::America::Cancun 2.51
+      DateTime::TimeZone::America::Caracas 2.51
+      DateTime::TimeZone::America::Cayenne 2.51
+      DateTime::TimeZone::America::Chicago 2.51
+      DateTime::TimeZone::America::Chihuahua 2.51
+      DateTime::TimeZone::America::Costa_Rica 2.51
+      DateTime::TimeZone::America::Cuiaba 2.51
+      DateTime::TimeZone::America::Danmarkshavn 2.51
+      DateTime::TimeZone::America::Dawson 2.51
+      DateTime::TimeZone::America::Dawson_Creek 2.51
+      DateTime::TimeZone::America::Denver 2.51
+      DateTime::TimeZone::America::Detroit 2.51
+      DateTime::TimeZone::America::Edmonton 2.51
+      DateTime::TimeZone::America::Eirunepe 2.51
+      DateTime::TimeZone::America::El_Salvador 2.51
+      DateTime::TimeZone::America::Fort_Nelson 2.51
+      DateTime::TimeZone::America::Fortaleza 2.51
+      DateTime::TimeZone::America::Glace_Bay 2.51
+      DateTime::TimeZone::America::Goose_Bay 2.51
+      DateTime::TimeZone::America::Grand_Turk 2.51
+      DateTime::TimeZone::America::Guatemala 2.51
+      DateTime::TimeZone::America::Guayaquil 2.51
+      DateTime::TimeZone::America::Guyana 2.51
+      DateTime::TimeZone::America::Halifax 2.51
+      DateTime::TimeZone::America::Havana 2.51
+      DateTime::TimeZone::America::Hermosillo 2.51
+      DateTime::TimeZone::America::Indiana::Indianapolis 2.51
+      DateTime::TimeZone::America::Indiana::Knox 2.51
+      DateTime::TimeZone::America::Indiana::Marengo 2.51
+      DateTime::TimeZone::America::Indiana::Petersburg 2.51
+      DateTime::TimeZone::America::Indiana::Tell_City 2.51
+      DateTime::TimeZone::America::Indiana::Vevay 2.51
+      DateTime::TimeZone::America::Indiana::Vincennes 2.51
+      DateTime::TimeZone::America::Indiana::Winamac 2.51
+      DateTime::TimeZone::America::Inuvik 2.51
+      DateTime::TimeZone::America::Iqaluit 2.51
+      DateTime::TimeZone::America::Jamaica 2.51
+      DateTime::TimeZone::America::Juneau 2.51
+      DateTime::TimeZone::America::Kentucky::Louisville 2.51
+      DateTime::TimeZone::America::Kentucky::Monticello 2.51
+      DateTime::TimeZone::America::La_Paz 2.51
+      DateTime::TimeZone::America::Lima 2.51
+      DateTime::TimeZone::America::Los_Angeles 2.51
+      DateTime::TimeZone::America::Maceio 2.51
+      DateTime::TimeZone::America::Managua 2.51
+      DateTime::TimeZone::America::Manaus 2.51
+      DateTime::TimeZone::America::Martinique 2.51
+      DateTime::TimeZone::America::Matamoros 2.51
+      DateTime::TimeZone::America::Mazatlan 2.51
+      DateTime::TimeZone::America::Menominee 2.51
+      DateTime::TimeZone::America::Merida 2.51
+      DateTime::TimeZone::America::Metlakatla 2.51
+      DateTime::TimeZone::America::Mexico_City 2.51
+      DateTime::TimeZone::America::Miquelon 2.51
+      DateTime::TimeZone::America::Moncton 2.51
+      DateTime::TimeZone::America::Monterrey 2.51
+      DateTime::TimeZone::America::Montevideo 2.51
+      DateTime::TimeZone::America::New_York 2.51
+      DateTime::TimeZone::America::Nipigon 2.51
+      DateTime::TimeZone::America::Nome 2.51
+      DateTime::TimeZone::America::Noronha 2.51
+      DateTime::TimeZone::America::North_Dakota::Beulah 2.51
+      DateTime::TimeZone::America::North_Dakota::Center 2.51
+      DateTime::TimeZone::America::North_Dakota::New_Salem 2.51
+      DateTime::TimeZone::America::Nuuk 2.51
+      DateTime::TimeZone::America::Ojinaga 2.51
+      DateTime::TimeZone::America::Panama 2.51
+      DateTime::TimeZone::America::Pangnirtung 2.51
+      DateTime::TimeZone::America::Paramaribo 2.51
+      DateTime::TimeZone::America::Phoenix 2.51
+      DateTime::TimeZone::America::Port_au_Prince 2.51
+      DateTime::TimeZone::America::Porto_Velho 2.51
+      DateTime::TimeZone::America::Puerto_Rico 2.51
+      DateTime::TimeZone::America::Punta_Arenas 2.51
+      DateTime::TimeZone::America::Rainy_River 2.51
+      DateTime::TimeZone::America::Rankin_Inlet 2.51
+      DateTime::TimeZone::America::Recife 2.51
+      DateTime::TimeZone::America::Regina 2.51
+      DateTime::TimeZone::America::Resolute 2.51
+      DateTime::TimeZone::America::Rio_Branco 2.51
+      DateTime::TimeZone::America::Santarem 2.51
+      DateTime::TimeZone::America::Santiago 2.51
+      DateTime::TimeZone::America::Santo_Domingo 2.51
+      DateTime::TimeZone::America::Sao_Paulo 2.51
+      DateTime::TimeZone::America::Scoresbysund 2.51
+      DateTime::TimeZone::America::Sitka 2.51
+      DateTime::TimeZone::America::St_Johns 2.51
+      DateTime::TimeZone::America::Swift_Current 2.51
+      DateTime::TimeZone::America::Tegucigalpa 2.51
+      DateTime::TimeZone::America::Thule 2.51
+      DateTime::TimeZone::America::Thunder_Bay 2.51
+      DateTime::TimeZone::America::Tijuana 2.51
+      DateTime::TimeZone::America::Toronto 2.51
+      DateTime::TimeZone::America::Vancouver 2.51
+      DateTime::TimeZone::America::Whitehorse 2.51
+      DateTime::TimeZone::America::Winnipeg 2.51
+      DateTime::TimeZone::America::Yakutat 2.51
+      DateTime::TimeZone::America::Yellowknife 2.51
+      DateTime::TimeZone::Antarctica::Casey 2.51
+      DateTime::TimeZone::Antarctica::Davis 2.51
+      DateTime::TimeZone::Antarctica::Macquarie 2.51
+      DateTime::TimeZone::Antarctica::Mawson 2.51
+      DateTime::TimeZone::Antarctica::Palmer 2.51
+      DateTime::TimeZone::Antarctica::Rothera 2.51
+      DateTime::TimeZone::Antarctica::Troll 2.51
+      DateTime::TimeZone::Antarctica::Vostok 2.51
+      DateTime::TimeZone::Asia::Almaty 2.51
+      DateTime::TimeZone::Asia::Amman 2.51
+      DateTime::TimeZone::Asia::Anadyr 2.51
+      DateTime::TimeZone::Asia::Aqtau 2.51
+      DateTime::TimeZone::Asia::Aqtobe 2.51
+      DateTime::TimeZone::Asia::Ashgabat 2.51
+      DateTime::TimeZone::Asia::Atyrau 2.51
+      DateTime::TimeZone::Asia::Baghdad 2.51
+      DateTime::TimeZone::Asia::Baku 2.51
+      DateTime::TimeZone::Asia::Bangkok 2.51
+      DateTime::TimeZone::Asia::Barnaul 2.51
+      DateTime::TimeZone::Asia::Beirut 2.51
+      DateTime::TimeZone::Asia::Bishkek 2.51
+      DateTime::TimeZone::Asia::Brunei 2.51
+      DateTime::TimeZone::Asia::Chita 2.51
+      DateTime::TimeZone::Asia::Choibalsan 2.51
+      DateTime::TimeZone::Asia::Colombo 2.51
+      DateTime::TimeZone::Asia::Damascus 2.51
+      DateTime::TimeZone::Asia::Dhaka 2.51
+      DateTime::TimeZone::Asia::Dili 2.51
+      DateTime::TimeZone::Asia::Dubai 2.51
+      DateTime::TimeZone::Asia::Dushanbe 2.51
+      DateTime::TimeZone::Asia::Famagusta 2.51
+      DateTime::TimeZone::Asia::Gaza 2.51
+      DateTime::TimeZone::Asia::Hebron 2.51
+      DateTime::TimeZone::Asia::Ho_Chi_Minh 2.51
+      DateTime::TimeZone::Asia::Hong_Kong 2.51
+      DateTime::TimeZone::Asia::Hovd 2.51
+      DateTime::TimeZone::Asia::Irkutsk 2.51
+      DateTime::TimeZone::Asia::Jakarta 2.51
+      DateTime::TimeZone::Asia::Jayapura 2.51
+      DateTime::TimeZone::Asia::Jerusalem 2.51
+      DateTime::TimeZone::Asia::Kabul 2.51
+      DateTime::TimeZone::Asia::Kamchatka 2.51
+      DateTime::TimeZone::Asia::Karachi 2.51
+      DateTime::TimeZone::Asia::Kathmandu 2.51
+      DateTime::TimeZone::Asia::Khandyga 2.51
+      DateTime::TimeZone::Asia::Kolkata 2.51
+      DateTime::TimeZone::Asia::Krasnoyarsk 2.51
+      DateTime::TimeZone::Asia::Kuala_Lumpur 2.51
+      DateTime::TimeZone::Asia::Kuching 2.51
+      DateTime::TimeZone::Asia::Macau 2.51
+      DateTime::TimeZone::Asia::Magadan 2.51
+      DateTime::TimeZone::Asia::Makassar 2.51
+      DateTime::TimeZone::Asia::Manila 2.51
+      DateTime::TimeZone::Asia::Nicosia 2.51
+      DateTime::TimeZone::Asia::Novokuznetsk 2.51
+      DateTime::TimeZone::Asia::Novosibirsk 2.51
+      DateTime::TimeZone::Asia::Omsk 2.51
+      DateTime::TimeZone::Asia::Oral 2.51
+      DateTime::TimeZone::Asia::Pontianak 2.51
+      DateTime::TimeZone::Asia::Pyongyang 2.51
+      DateTime::TimeZone::Asia::Qatar 2.51
+      DateTime::TimeZone::Asia::Qostanay 2.51
+      DateTime::TimeZone::Asia::Qyzylorda 2.51
+      DateTime::TimeZone::Asia::Riyadh 2.51
+      DateTime::TimeZone::Asia::Sakhalin 2.51
+      DateTime::TimeZone::Asia::Samarkand 2.51
+      DateTime::TimeZone::Asia::Seoul 2.51
+      DateTime::TimeZone::Asia::Shanghai 2.51
+      DateTime::TimeZone::Asia::Singapore 2.51
+      DateTime::TimeZone::Asia::Srednekolymsk 2.51
+      DateTime::TimeZone::Asia::Taipei 2.51
+      DateTime::TimeZone::Asia::Tashkent 2.51
+      DateTime::TimeZone::Asia::Tbilisi 2.51
+      DateTime::TimeZone::Asia::Tehran 2.51
+      DateTime::TimeZone::Asia::Thimphu 2.51
+      DateTime::TimeZone::Asia::Tokyo 2.51
+      DateTime::TimeZone::Asia::Tomsk 2.51
+      DateTime::TimeZone::Asia::Ulaanbaatar 2.51
+      DateTime::TimeZone::Asia::Urumqi 2.51
+      DateTime::TimeZone::Asia::Ust_Nera 2.51
+      DateTime::TimeZone::Asia::Vladivostok 2.51
+      DateTime::TimeZone::Asia::Yakutsk 2.51
+      DateTime::TimeZone::Asia::Yangon 2.51
+      DateTime::TimeZone::Asia::Yekaterinburg 2.51
+      DateTime::TimeZone::Asia::Yerevan 2.51
+      DateTime::TimeZone::Atlantic::Azores 2.51
+      DateTime::TimeZone::Atlantic::Bermuda 2.51
+      DateTime::TimeZone::Atlantic::Canary 2.51
+      DateTime::TimeZone::Atlantic::Cape_Verde 2.51
+      DateTime::TimeZone::Atlantic::Faroe 2.51
+      DateTime::TimeZone::Atlantic::Madeira 2.51
+      DateTime::TimeZone::Atlantic::Reykjavik 2.51
+      DateTime::TimeZone::Atlantic::South_Georgia 2.51
+      DateTime::TimeZone::Atlantic::Stanley 2.51
+      DateTime::TimeZone::Australia::Adelaide 2.51
+      DateTime::TimeZone::Australia::Brisbane 2.51
+      DateTime::TimeZone::Australia::Broken_Hill 2.51
+      DateTime::TimeZone::Australia::Darwin 2.51
+      DateTime::TimeZone::Australia::Eucla 2.51
+      DateTime::TimeZone::Australia::Hobart 2.51
+      DateTime::TimeZone::Australia::Lindeman 2.51
+      DateTime::TimeZone::Australia::Lord_Howe 2.51
+      DateTime::TimeZone::Australia::Melbourne 2.51
+      DateTime::TimeZone::Australia::Perth 2.51
+      DateTime::TimeZone::Australia::Sydney 2.51
+      DateTime::TimeZone::CET 2.51
+      DateTime::TimeZone::CST6CDT 2.51
+      DateTime::TimeZone::Catalog 2.51
+      DateTime::TimeZone::EET 2.51
+      DateTime::TimeZone::EST 2.51
+      DateTime::TimeZone::EST5EDT 2.51
+      DateTime::TimeZone::Europe::Amsterdam 2.51
+      DateTime::TimeZone::Europe::Andorra 2.51
+      DateTime::TimeZone::Europe::Astrakhan 2.51
+      DateTime::TimeZone::Europe::Athens 2.51
+      DateTime::TimeZone::Europe::Belgrade 2.51
+      DateTime::TimeZone::Europe::Berlin 2.51
+      DateTime::TimeZone::Europe::Brussels 2.51
+      DateTime::TimeZone::Europe::Bucharest 2.51
+      DateTime::TimeZone::Europe::Budapest 2.51
+      DateTime::TimeZone::Europe::Chisinau 2.51
+      DateTime::TimeZone::Europe::Copenhagen 2.51
+      DateTime::TimeZone::Europe::Dublin 2.51
+      DateTime::TimeZone::Europe::Gibraltar 2.51
+      DateTime::TimeZone::Europe::Helsinki 2.51
+      DateTime::TimeZone::Europe::Istanbul 2.51
+      DateTime::TimeZone::Europe::Kaliningrad 2.51
+      DateTime::TimeZone::Europe::Kiev 2.51
+      DateTime::TimeZone::Europe::Kirov 2.51
+      DateTime::TimeZone::Europe::Lisbon 2.51
+      DateTime::TimeZone::Europe::London 2.51
+      DateTime::TimeZone::Europe::Luxembourg 2.51
+      DateTime::TimeZone::Europe::Madrid 2.51
+      DateTime::TimeZone::Europe::Malta 2.51
+      DateTime::TimeZone::Europe::Minsk 2.51
+      DateTime::TimeZone::Europe::Monaco 2.51
+      DateTime::TimeZone::Europe::Moscow 2.51
+      DateTime::TimeZone::Europe::Oslo 2.51
+      DateTime::TimeZone::Europe::Paris 2.51
+      DateTime::TimeZone::Europe::Prague 2.51
+      DateTime::TimeZone::Europe::Riga 2.51
+      DateTime::TimeZone::Europe::Rome 2.51
+      DateTime::TimeZone::Europe::Samara 2.51
+      DateTime::TimeZone::Europe::Saratov 2.51
+      DateTime::TimeZone::Europe::Simferopol 2.51
+      DateTime::TimeZone::Europe::Sofia 2.51
+      DateTime::TimeZone::Europe::Stockholm 2.51
+      DateTime::TimeZone::Europe::Tallinn 2.51
+      DateTime::TimeZone::Europe::Tirane 2.51
+      DateTime::TimeZone::Europe::Ulyanovsk 2.51
+      DateTime::TimeZone::Europe::Uzhgorod 2.51
+      DateTime::TimeZone::Europe::Vienna 2.51
+      DateTime::TimeZone::Europe::Vilnius 2.51
+      DateTime::TimeZone::Europe::Volgograd 2.51
+      DateTime::TimeZone::Europe::Warsaw 2.51
+      DateTime::TimeZone::Europe::Zaporozhye 2.51
+      DateTime::TimeZone::Europe::Zurich 2.51
+      DateTime::TimeZone::Floating 2.51
+      DateTime::TimeZone::HST 2.51
+      DateTime::TimeZone::Indian::Chagos 2.51
+      DateTime::TimeZone::Indian::Christmas 2.51
+      DateTime::TimeZone::Indian::Cocos 2.51
+      DateTime::TimeZone::Indian::Kerguelen 2.51
+      DateTime::TimeZone::Indian::Mahe 2.51
+      DateTime::TimeZone::Indian::Maldives 2.51
+      DateTime::TimeZone::Indian::Mauritius 2.51
+      DateTime::TimeZone::Indian::Reunion 2.51
+      DateTime::TimeZone::Local 2.51
+      DateTime::TimeZone::Local::Android 2.51
+      DateTime::TimeZone::Local::Unix 2.51
+      DateTime::TimeZone::Local::VMS 2.51
+      DateTime::TimeZone::MET 2.51
+      DateTime::TimeZone::MST 2.51
+      DateTime::TimeZone::MST7MDT 2.51
+      DateTime::TimeZone::OffsetOnly 2.51
+      DateTime::TimeZone::OlsonDB 2.51
+      DateTime::TimeZone::OlsonDB::Change 2.51
+      DateTime::TimeZone::OlsonDB::Observance 2.51
+      DateTime::TimeZone::OlsonDB::Rule 2.51
+      DateTime::TimeZone::OlsonDB::Zone 2.51
+      DateTime::TimeZone::PST8PDT 2.51
+      DateTime::TimeZone::Pacific::Apia 2.51
+      DateTime::TimeZone::Pacific::Auckland 2.51
+      DateTime::TimeZone::Pacific::Bougainville 2.51
+      DateTime::TimeZone::Pacific::Chatham 2.51
+      DateTime::TimeZone::Pacific::Chuuk 2.51
+      DateTime::TimeZone::Pacific::Easter 2.51
+      DateTime::TimeZone::Pacific::Efate 2.51
+      DateTime::TimeZone::Pacific::Fakaofo 2.51
+      DateTime::TimeZone::Pacific::Fiji 2.51
+      DateTime::TimeZone::Pacific::Funafuti 2.51
+      DateTime::TimeZone::Pacific::Galapagos 2.51
+      DateTime::TimeZone::Pacific::Gambier 2.51
+      DateTime::TimeZone::Pacific::Guadalcanal 2.51
+      DateTime::TimeZone::Pacific::Guam 2.51
+      DateTime::TimeZone::Pacific::Honolulu 2.51
+      DateTime::TimeZone::Pacific::Kanton 2.51
+      DateTime::TimeZone::Pacific::Kiritimati 2.51
+      DateTime::TimeZone::Pacific::Kosrae 2.51
+      DateTime::TimeZone::Pacific::Kwajalein 2.51
+      DateTime::TimeZone::Pacific::Majuro 2.51
+      DateTime::TimeZone::Pacific::Marquesas 2.51
+      DateTime::TimeZone::Pacific::Nauru 2.51
+      DateTime::TimeZone::Pacific::Niue 2.51
+      DateTime::TimeZone::Pacific::Norfolk 2.51
+      DateTime::TimeZone::Pacific::Noumea 2.51
+      DateTime::TimeZone::Pacific::Pago_Pago 2.51
+      DateTime::TimeZone::Pacific::Palau 2.51
+      DateTime::TimeZone::Pacific::Pitcairn 2.51
+      DateTime::TimeZone::Pacific::Pohnpei 2.51
+      DateTime::TimeZone::Pacific::Port_Moresby 2.51
+      DateTime::TimeZone::Pacific::Rarotonga 2.51
+      DateTime::TimeZone::Pacific::Tahiti 2.51
+      DateTime::TimeZone::Pacific::Tarawa 2.51
+      DateTime::TimeZone::Pacific::Tongatapu 2.51
+      DateTime::TimeZone::Pacific::Wake 2.51
+      DateTime::TimeZone::Pacific::Wallis 2.51
+      DateTime::TimeZone::UTC 2.51
+      DateTime::TimeZone::WET 2.51
+    requirements:
+      Class::Singleton 1.03
+      Cwd 3
+      ExtUtils::MakeMaker 0
+      File::Basename 0
+      File::Compare 0
+      File::Find 0
+      File::Spec 0
+      List::Util 1.33
+      Module::Runtime 0
+      Params::ValidationCompiler 0.13
+      Specio::Library::Builtins 0
+      Specio::Library::String 0
+      Try::Tiny 0
+      constant 0
+      namespace::autoclean 0
+      parent 0
+      perl 5.008004
+      strict 0
+      warnings 0
+  Devel-CheckCompiler-0.07
+    pathname: S/SY/SYOHEX/Devel-CheckCompiler-0.07.tar.gz
+    provides:
+      Devel::AssertC99 undef
+      Devel::CheckCompiler 0.07
+    requirements:
+      Exporter 0
+      ExtUtils::CBuilder 0
+      File::Temp 0
+      Module::Build::Tiny 0.035
+      Test::More 0.98
+      parent 0
+      perl 5.008001
+  Devel-PPPort-3.63
+    pathname: A/AT/ATOOMIC/Devel-PPPort-3.63.tar.gz
+    provides:
+      Devel::PPPort 3.63
+    requirements:
+      ExtUtils::MakeMaker 0
+      FindBin 0
+  Devel-StackTrace-2.04
+    pathname: D/DR/DROLSKY/Devel-StackTrace-2.04.tar.gz
+    provides:
+      Devel::StackTrace 2.04
+      Devel::StackTrace::Frame 2.04
+    requirements:
+      ExtUtils::MakeMaker 0
+      File::Spec 0
+      Scalar::Util 0
+      overload 0
+      perl 5.006
+      strict 0
+      warnings 0
+  Devel-StackTrace-AsHTML-0.15
+    pathname: M/MI/MIYAGAWA/Devel-StackTrace-AsHTML-0.15.tar.gz
+    provides:
+      Devel::StackTrace::AsHTML 0.15
+    requirements:
+      Devel::StackTrace 0
+      ExtUtils::MakeMaker 0
+  Digest-HMAC-1.04
+    pathname: A/AR/ARODLAND/Digest-HMAC-1.04.tar.gz
+    provides:
+      Digest::HMAC 1.04
+      Digest::HMAC_MD5 1.04
+      Digest::HMAC_SHA1 1.04
+    requirements:
+      Digest::MD5 2
+      Digest::SHA 1
+      ExtUtils::MakeMaker 0
+      perl 5.004
+  Digest-SHA1-2.13
+    pathname: G/GA/GAAS/Digest-SHA1-2.13.tar.gz
+    provides:
+      Digest::SHA1 2.13
+    requirements:
+      Digest::base 1.00
+      ExtUtils::MakeMaker 0
+      perl 5.004
+  Digest-SHA3-1.04
+    pathname: M/MS/MSHELOR/Digest-SHA3-1.04.tar.gz
+    provides:
+      Digest::SHA3 1.04
+    requirements:
+      ExtUtils::MakeMaker 0
+  Dist-CheckConflicts-0.11
+    pathname: D/DO/DOY/Dist-CheckConflicts-0.11.tar.gz
+    provides:
+      Dist::CheckConflicts 0.11
+    requirements:
+      Carp 0
+      Exporter 0
+      ExtUtils::MakeMaker 6.30
+      Module::Runtime 0.009
+      base 0
+      strict 0
+      warnings 0
+  Encode-3.16
+    pathname: D/DA/DANKOGAI/Encode-3.16.tar.gz
+    provides:
+      Encode 3.16
+      Encode::Alias 2.24
+      Encode::Byte 2.04
+      Encode::CJKConstants 2.02
+      Encode::CN 2.03
+      Encode::CN::HZ 2.10
+      Encode::Config 2.05
+      Encode::EBCDIC 2.02
+      Encode::Encoder 2.03
+      Encode::Encoding 2.08
+      Encode::GSM0338 2.10
+      Encode::Guess 2.08
+      Encode::JP 2.05
+      Encode::JP::H2Z 2.02
+      Encode::JP::JIS7 2.08
+      Encode::KR 2.03
+      Encode::KR::2022_KR 2.04
+      Encode::MIME::Header 2.28
+      Encode::MIME::Header::ISO_2022_JP 1.09
+      Encode::MIME::Name 1.03
+      Encode::Symbol 2.02
+      Encode::TW 2.03
+      Encode::UTF_EBCDIC 3.16
+      Encode::Unicode 2.19
+      Encode::Unicode::UTF7 2.10
+      Encode::XS 3.16
+      Encode::utf8 3.16
+      encoding 3.00
+    requirements:
+      Exporter 5.57
+      ExtUtils::MakeMaker 0
+      Storable 0
+      parent 0.221
+  Encode-Locale-1.05
+    pathname: G/GA/GAAS/Encode-Locale-1.05.tar.gz
+    provides:
+      Encode::Locale 1.05
+    requirements:
+      Encode 2
+      Encode::Alias 0
+      ExtUtils::MakeMaker 0
+      perl 5.008
+  Error-0.17029
+    pathname: S/SH/SHLOMIF/Error-0.17029.tar.gz
+    provides:
+      Error 0.17029
+      Error::Simple 0.17029
+    requirements:
+      Carp 0
+      Exporter 0
+      ExtUtils::MakeMaker 0
+      Module::Build 0.28
+      Scalar::Util 0
+      overload 0
+      perl 5.006
+      strict 0
+      vars 0
+      warnings 0
+  Eval-Closure-0.14
+    pathname: D/DO/DOY/Eval-Closure-0.14.tar.gz
+    provides:
+      Eval::Closure 0.14
+    requirements:
+      Carp 0
+      Exporter 0
+      ExtUtils::MakeMaker 0
+      Scalar::Util 0
+      constant 0
+      overload 0
+      strict 0
+      warnings 0
+  Exception-Class-1.45
+    pathname: D/DR/DROLSKY/Exception-Class-1.45.tar.gz
+    provides:
+      Exception::Class 1.45
+      Exception::Class::Base 1.45
+    requirements:
+      Carp 0
+      Class::Data::Inheritable 0.02
+      Devel::StackTrace 2.00
+      ExtUtils::MakeMaker 0
+      Scalar::Util 0
+      base 0
+      overload 0
+      perl 5.008001
+      strict 0
+      warnings 0
+  Exporter-Tiny-1.002002
+    pathname: T/TO/TOBYINK/Exporter-Tiny-1.002002.tar.gz
+    provides:
+      Exporter::Shiny 1.002002
+      Exporter::Tiny 1.002002
+    requirements:
+      ExtUtils::MakeMaker 6.17
+      perl 5.006001
+  ExtUtils-Config-0.008
+    pathname: L/LE/LEONT/ExtUtils-Config-0.008.tar.gz
+    provides:
+      ExtUtils::Config 0.008
+    requirements:
+      Data::Dumper 0
+      ExtUtils::MakeMaker 6.30
+      strict 0
+      warnings 0
+  ExtUtils-Depends-0.8001
+    pathname: X/XA/XAOC/ExtUtils-Depends-0.8001.tar.gz
+    provides:
+      ExtUtils::Depends 0.8001
+    requirements:
+      Data::Dumper 0
+      ExtUtils::MakeMaker 7.44
+      File::Spec 0
+      IO::File 0
+      perl 5.006
+  ExtUtils-Helpers-0.026
+    pathname: L/LE/LEONT/ExtUtils-Helpers-0.026.tar.gz
+    provides:
+      ExtUtils::Helpers 0.026
+      ExtUtils::Helpers::Unix 0.026
+      ExtUtils::Helpers::VMS 0.026
+      ExtUtils::Helpers::Windows 0.026
+    requirements:
+      Carp 0
+      Exporter 5.57
+      ExtUtils::MakeMaker 0
+      File::Basename 0
+      File::Copy 0
+      File::Spec::Functions 0
+      Text::ParseWords 3.24
+      perl 5.006
+      strict 0
+      warnings 0
+  ExtUtils-InstallPaths-0.012
+    pathname: L/LE/LEONT/ExtUtils-InstallPaths-0.012.tar.gz
+    provides:
+      ExtUtils::InstallPaths 0.012
+    requirements:
+      Carp 0
+      ExtUtils::Config 0.002
+      ExtUtils::MakeMaker 0
+      File::Spec 0
+      perl 5.006
+      strict 0
+      warnings 0
+  ExtUtils-MakeMaker-7.64
+    pathname: B/BI/BINGOS/ExtUtils-MakeMaker-7.64.tar.gz
+    provides:
+      DynaLoader 7.64
+      ExtUtils::Command 7.64
+      ExtUtils::Command::MM 7.64
+      ExtUtils::Liblist 7.64
+      ExtUtils::Liblist::Kid 7.64
+      ExtUtils::MM 7.64
+      ExtUtils::MM_AIX 7.64
+      ExtUtils::MM_Any 7.64
+      ExtUtils::MM_BeOS 7.64
+      ExtUtils::MM_Cygwin 7.64
+      ExtUtils::MM_DOS 7.64
+      ExtUtils::MM_Darwin 7.64
+      ExtUtils::MM_MacOS 7.64
+      ExtUtils::MM_NW5 7.64
+      ExtUtils::MM_OS2 7.64
+      ExtUtils::MM_OS390 7.64
+      ExtUtils::MM_QNX 7.64
+      ExtUtils::MM_UWIN 7.64
+      ExtUtils::MM_Unix 7.64
+      ExtUtils::MM_VMS 7.64
+      ExtUtils::MM_VOS 7.64
+      ExtUtils::MM_Win32 7.64
+      ExtUtils::MM_Win95 7.64
+      ExtUtils::MY 7.64
+      ExtUtils::MakeMaker 7.64
+      ExtUtils::MakeMaker::Config 7.64
+      ExtUtils::MakeMaker::Locale 7.64
+      ExtUtils::MakeMaker::_version 7.64
+      ExtUtils::MakeMaker::charstar 7.64
+      ExtUtils::MakeMaker::version 7.64
+      ExtUtils::MakeMaker::version::regex 7.64
+      ExtUtils::MakeMaker::version::vpp 7.64
+      ExtUtils::Mkbootstrap 7.64
+      ExtUtils::Mksymlists 7.64
+      ExtUtils::testlib 7.64
+      MM 7.64
+      MY 7.64
+      in 7.64
+    requirements:
+      Data::Dumper 0
+      Encode 0
+      File::Basename 0
+      File::Spec 0.8
+      Pod::Man 0
+      perl 5.006
+  ExtUtils-ParseXS-3.35
+    pathname: S/SM/SMUELLER/ExtUtils-ParseXS-3.35.tar.gz
+    provides:
+      ExtUtils::ParseXS 3.35
+      ExtUtils::ParseXS::Constants 3.35
+      ExtUtils::ParseXS::CountLines 3.35
+      ExtUtils::ParseXS::Eval 3.35
+      ExtUtils::ParseXS::Utilities 3.35
+      ExtUtils::Typemaps 3.35
+      ExtUtils::Typemaps::Cmd 3.35
+      ExtUtils::Typemaps::InputMap 3.35
+      ExtUtils::Typemaps::OutputMap 3.35
+      ExtUtils::Typemaps::Type 3.35
+    requirements:
+      Carp 0
+      Cwd 0
+      DynaLoader 0
+      Exporter 5.57
+      ExtUtils::CBuilder 0
+      ExtUtils::MakeMaker 6.46
+      File::Basename 0
+      File::Spec 0
+      Symbol 0
+      Test::More 0.47
+  File-Copy-Recursive-0.45
+    pathname: D/DM/DMUEY/File-Copy-Recursive-0.45.tar.gz
+    provides:
+      File::Copy::Recursive 0.45
+    requirements:
+      Cwd 0
+      ExtUtils::MakeMaker 0
+      File::Copy 0
+      File::Glob 0
+      File::Spec 0
+  File-Find-Rule-0.34
+    pathname: R/RC/RCLAMP/File-Find-Rule-0.34.tar.gz
+    provides:
+      File::Find::Rule 0.34
+      File::Find::Rule::Test::ATeam undef
+    requirements:
+      ExtUtils::MakeMaker 0
+      File::Find 0
+      File::Spec 0
+      Number::Compare 0
+      Test::More 0
+      Text::Glob 0.07
+  File-HomeDir-1.006
+    pathname: R/RE/REHSACK/File-HomeDir-1.006.tar.gz
+    provides:
+      File::HomeDir 1.006
+      File::HomeDir::Darwin 1.006
+      File::HomeDir::Darwin::Carbon 1.006
+      File::HomeDir::Darwin::Cocoa 1.006
+      File::HomeDir::Driver 1.006
+      File::HomeDir::FreeDesktop 1.006
+      File::HomeDir::MacOS9 1.006
+      File::HomeDir::Test 1.006
+      File::HomeDir::Unix 1.006
+      File::HomeDir::Windows 1.006
+    requirements:
+      Carp 0
+      Cwd 3.12
+      ExtUtils::MakeMaker 0
+      File::Basename 0
+      File::Path 2.01
+      File::Spec 3.12
+      File::Temp 0.19
+      File::Which 0.05
+      POSIX 0
+      perl 5.008003
+  File-Listing-6.14
+    pathname: P/PL/PLICEASE/File-Listing-6.14.tar.gz
+    provides:
+      File::Listing 6.14
+      File::Listing::apache 6.14
+      File::Listing::dosftp 6.14
+      File::Listing::netware 6.14
+      File::Listing::unix 6.14
+      File::Listing::vms 6.14
+    requirements:
+      Carp 0
+      Exporter 0
+      ExtUtils::MakeMaker 0
+      HTTP::Date 0
+      Time::Local 0
+      base 0
+      perl 5.006
+  File-ShareDir-1.118
+    pathname: R/RE/REHSACK/File-ShareDir-1.118.tar.gz
+    provides:
+      File::ShareDir 1.118
+    requirements:
+      Carp 0
+      Class::Inspector 1.12
+      ExtUtils::MakeMaker 0
+      File::ShareDir::Install 0.13
+      File::Spec 0.80
+      perl 5.008001
+      warnings 0
+  File-ShareDir-Install-0.13
+    pathname: E/ET/ETHER/File-ShareDir-Install-0.13.tar.gz
+    provides:
+      File::ShareDir::Install 0.13
+    requirements:
+      Carp 0
+      Exporter 0
+      ExtUtils::MakeMaker 0
+      File::Spec 0
+      IO::Dir 0
+      perl 5.006
+      strict 0
+      warnings 0
+  File-Slurp-9999.32
+    pathname: C/CA/CAPOEIRAB/File-Slurp-9999.32.tar.gz
+    provides:
+      File::Slurp 9999.32
+    requirements:
+      B 0
+      Carp 0
+      Errno 0
+      Exporter 5.57
+      ExtUtils::MakeMaker 0
+      Fcntl 0
+      File::Basename 0
+      File::Spec 3.01
+      File::Temp 0
+      IO::Handle 0
+      POSIX 0
+      strict 0
+      warnings 0
+  File-Which-1.27
+    pathname: P/PL/PLICEASE/File-Which-1.27.tar.gz
+    provides:
+      File::Which 1.27
+    requirements:
+      ExtUtils::MakeMaker 0
+      base 0
+      perl 5.006
+  Filesys-Notify-Simple-0.14
+    pathname: M/MI/MIYAGAWA/Filesys-Notify-Simple-0.14.tar.gz
+    provides:
+      Filesys::Notify::Simple 0.14
+    requirements:
+      ExtUtils::MakeMaker 0
+      perl 5.008001
+  HTML-FillInForm-Lite-1.15
+    pathname: G/GF/GFUJI/HTML-FillInForm-Lite-1.15.tar.gz
+    provides:
+      HTML::FillInForm::Lite 1.15
+      HTML::FillInForm::Lite::Compat 1.15
+    requirements:
+      ExtUtils::MakeMaker 6.59
+      Module::Build::Tiny 0.035
+      perl 5.008001
+  HTML-Parser-3.76
+    pathname: O/OA/OALDERS/HTML-Parser-3.76.tar.gz
+    provides:
+      HTML::Entities 3.76
+      HTML::Filter 3.76
+      HTML::HeadParser 3.76
+      HTML::LinkExtor 3.76
+      HTML::Parser 3.76
+      HTML::PullParser 3.76
+      HTML::TokeParser 3.76
+    requirements:
+      Carp 0
+      Exporter 0
+      ExtUtils::MakeMaker 6.52
+      HTML::Tagset 0
+      HTTP::Headers 0
+      IO::File 0
+      URI 0
+      URI::URL 0
+      XSLoader 0
+      strict 0
+  HTML-Selector-XPath-0.26
+    pathname: C/CO/CORION/HTML-Selector-XPath-0.26.tar.gz
+    provides:
+      HTML::Selector::XPath 0.26
+    requirements:
+      Carp 0
+      Exporter 0
+      ExtUtils::MakeMaker 0
+      perl 5.008001
+      strict 0
+  HTML-Tagset-3.20
+    pathname: P/PE/PETDANCE/HTML-Tagset-3.20.tar.gz
+    provides:
+      HTML::Tagset 3.20
+    requirements:
+      ExtUtils::MakeMaker 0
+  HTML-Tree-5.07
+    pathname: K/KE/KENTNL/HTML-Tree-5.07.tar.gz
+    provides:
+      HTML::AsSubs 5.07
+      HTML::Element 5.07
+      HTML::Element::traverse 5.07
+      HTML::Parse 5.07
+      HTML::Tree 5.07
+      HTML::TreeBuilder 5.07
+    requirements:
+      Carp 0
+      Encode 0
+      Exporter 0
+      HTML::Entities 0
+      HTML::Parser 3.46
+      HTML::Tagset 3.02
+      Module::Build 0.2808
+      Scalar::Util 0
+      Test::Fatal 0
+      Test::More 0
+      base 0
+      integer 0
+      perl 5.008
+  HTML-TreeBuilder-XPath-0.14
+    pathname: M/MI/MIROD/HTML-TreeBuilder-XPath-0.14.tar.gz
+    provides:
+      HTML::Element 0.14
+      HTML::TreeBuilder::XPath 0.14
+      HTML::TreeBuilder::XPath::Attribute 0.14
+      HTML::TreeBuilder::XPath::Node 0.14
+      HTML::TreeBuilder::XPath::Root 0.14
+      HTML::TreeBuilder::XPath::TextNode 0.14
+    requirements:
+      ExtUtils::MakeMaker 0
+      HTML::TreeBuilder 0
+      List::Util 0
+      XML::XPathEngine 0.12
+  HTTP-Cookies-6.10
+    pathname: O/OA/OALDERS/HTTP-Cookies-6.10.tar.gz
+    provides:
+      HTTP::Cookies 6.10
+      HTTP::Cookies::Microsoft 6.10
+      HTTP::Cookies::Netscape 6.10
+    requirements:
+      Carp 0
+      ExtUtils::MakeMaker 0
+      HTTP::Date 6
+      HTTP::Headers::Util 6
+      HTTP::Request 0
+      locale 0
+      perl 5.008001
+      strict 0
+  HTTP-Date-6.05
+    pathname: O/OA/OALDERS/HTTP-Date-6.05.tar.gz
+    provides:
+      HTTP::Date 6.05
+    requirements:
+      Exporter 0
+      ExtUtils::MakeMaker 0
+      Time::Local 1.28
+      Time::Zone 0
+      perl 5.006002
+      strict 0
+  HTTP-Entity-Parser-0.25
+    pathname: K/KA/KAZEBURO/HTTP-Entity-Parser-0.25.tar.gz
+    provides:
+      HTTP::Entity::Parser 0.25
+      HTTP::Entity::Parser::JSON undef
+      HTTP::Entity::Parser::MultiPart undef
+      HTTP::Entity::Parser::OctetStream undef
+      HTTP::Entity::Parser::UrlEncoded undef
+    requirements:
+      Encode 0
+      File::Temp 0
+      HTTP::MultiPartParser 0
+      Hash::MultiValue 0
+      JSON::MaybeXS 1.003007
+      Module::Build::Tiny 0.035
+      Module::Load 0
+      Stream::Buffered 0
+      WWW::Form::UrlEncoded 0.23
+      perl 5.008001
+  HTTP-Headers-Fast-0.22
+    pathname: T/TO/TOKUHIROM/HTTP-Headers-Fast-0.22.tar.gz
+    provides:
+      HTTP::Headers::Fast 0.22
+    requirements:
+      HTTP::Date 0
+      Module::Build::Tiny 0.035
+      perl 5.008001
+  HTTP-Message-6.35
+    pathname: O/OA/OALDERS/HTTP-Message-6.35.tar.gz
+    provides:
+      HTTP::Config 6.35
+      HTTP::Headers 6.35
+      HTTP::Headers::Auth 6.35
+      HTTP::Headers::ETag 6.35
+      HTTP::Headers::Util 6.35
+      HTTP::Message 6.35
+      HTTP::Request 6.35
+      HTTP::Request::Common 6.35
+      HTTP::Response 6.35
+      HTTP::Status 6.35
+    requirements:
+      Carp 0
+      Compress::Raw::Zlib 0
+      Encode 3.01
+      Encode::Locale 1
+      Exporter 5.57
+      ExtUtils::MakeMaker 0
+      File::Spec 0
+      HTTP::Date 6
+      IO::Compress::Bzip2 2.021
+      IO::Compress::Deflate 0
+      IO::Compress::Gzip 0
+      IO::HTML 0
+      IO::Uncompress::Bunzip2 2.021
+      IO::Uncompress::Gunzip 0
+      IO::Uncompress::Inflate 0
+      IO::Uncompress::RawInflate 0
+      LWP::MediaTypes 6
+      MIME::Base64 2.1
+      MIME::QuotedPrint 0
+      URI 1.10
+      base 0
+      perl 5.008001
+      strict 0
+      warnings 0
+  HTTP-MultiPartParser-0.02
+    pathname: C/CH/CHANSEN/HTTP-MultiPartParser-0.02.tar.gz
+    provides:
+      HTTP::MultiPartParser 0.02
+    requirements:
+      Carp 0
+      ExtUtils::MakeMaker 6.59
+      Scalar::Util 0
+      Test::Deep 0
+      Test::More 0.88
+      perl 5.008001
+  HTTP-Negotiate-6.01
+    pathname: G/GA/GAAS/HTTP-Negotiate-6.01.tar.gz
+    provides:
+      HTTP::Negotiate 6.01
+    requirements:
+      ExtUtils::MakeMaker 0
+      HTTP::Headers 6
+      perl 5.008001
+  HTTP-Session2-1.10
+    pathname: T/TO/TOKUHIROM/HTTP-Session2-1.10.tar.gz
+    provides:
+      HTTP::Session2 1.10
+      HTTP::Session2::Base undef
+      HTTP::Session2::ClientStore undef
+      HTTP::Session2::ClientStore2 undef
+      HTTP::Session2::Expired undef
+      HTTP::Session2::Random undef
+      HTTP::Session2::ServerStore 1.10
+    requirements:
+      Cookie::Baker 0
+      Crypt::CBC 0
+      Data::MessagePack 0
+      Digest::HMAC 0
+      Digest::SHA 0
+      Digest::SHA1 0
+      MIME::Base64 3.11
+      Module::Build::Tiny 0.035
+      Mouse 0
+      Time::HiRes 0
+      parent 0
+      perl 5.008005
+  HTTP-Tiny-0.080
+    pathname: D/DA/DAGOLDEN/HTTP-Tiny-0.080.tar.gz
+    provides:
+      HTTP::Tiny 0.080
+    requirements:
+      Carp 0
+      ExtUtils::MakeMaker 6.17
+      Fcntl 0
+      IO::Socket 0
+      MIME::Base64 0
+      Socket 0
+      Time::Local 0
+      bytes 0
+      perl 5.006
+      strict 0
+      warnings 0
+  Hash-MultiValue-0.16
+    pathname: A/AR/ARISTOTLE/Hash-MultiValue-0.16.tar.gz
+    provides:
+      Hash::MultiValue 0.16
+    requirements:
+      ExtUtils::MakeMaker 0
+      perl 5.008001
+  IO-HTML-1.004
+    pathname: C/CJ/CJM/IO-HTML-1.004.tar.gz
+    provides:
+      IO::HTML 1.004
+    requirements:
+      Carp 0
+      Encode 2.10
+      Exporter 5.57
+      ExtUtils::MakeMaker 0
+      perl 5.008
+  IO-Socket-IP-0.41
+    pathname: P/PE/PEVANS/IO-Socket-IP-0.41.tar.gz
+    provides:
+      IO::Socket::IP 0.41
+    requirements:
+      IO::Socket 0
+      Module::Build 0.4004
+      Socket 1.97
+  IPC-Signal-1.00
+    pathname: R/RO/ROSCH/IPC-Signal-1.00.tar.gz
+    provides:
+      IPC::Signal 1.00
+    requirements:
+      ExtUtils::MakeMaker 0
+  JSON-4.04
+    pathname: I/IS/ISHIGAKI/JSON-4.04.tar.gz
+    provides:
+      JSON 4.04
+      JSON::Backend::PP 4.04
+    requirements:
+      ExtUtils::MakeMaker 0
+      Test::More 0
+  JSON-MaybeXS-1.004003
+    pathname: E/ET/ETHER/JSON-MaybeXS-1.004003.tar.gz
+    provides:
+      ExtUtils::HasCompiler 0.021
+      JSON::MaybeXS 1.004003
+    requirements:
+      Carp 0
+      Cpanel::JSON::XS 2.3310
+      ExtUtils::MakeMaker 0
+      JSON::PP 2.27300
+      Scalar::Util 0
+      perl 5.006
+  JSON-PP-4.07
+    pathname: I/IS/ISHIGAKI/JSON-PP-4.07.tar.gz
+    provides:
+      JSON::PP 4.07
+      JSON::PP::Boolean 4.07
+      JSON::PP::IncrParser 4.07
+    requirements:
+      ExtUtils::MakeMaker 0
+      Scalar::Util 1.08
+      Test::More 0
+  JSON-XS-4.03
+    pathname: M/ML/MLEHMANN/JSON-XS-4.03.tar.gz
+    provides:
+      JSON::XS 4.03
+    requirements:
+      Canary::Stability 0
+      ExtUtils::MakeMaker 6.52
+      Types::Serialiser 0
+      common::sense 0
+  LWP-MediaTypes-6.04
+    pathname: O/OA/OALDERS/LWP-MediaTypes-6.04.tar.gz
+    provides:
+      LWP::MediaTypes 6.04
+    requirements:
+      Carp 0
+      Exporter 0
+      ExtUtils::MakeMaker 0
+      File::Basename 0
+      Scalar::Util 0
+      perl 5.006002
+      strict 0
+  LWP-UserAgent-WithCache-0.13
+    pathname: S/SE/SEKIMURA/LWP-UserAgent-WithCache-0.13.tar.gz
+    provides:
+      LWP::UserAgent::WithCache 0.13
+    requirements:
+      Cache::FileCache 0
+      ExtUtils::MakeMaker 0
+      File::HomeDir 0
+      LWP::UserAgent 0
+  List-MoreUtils-0.430
+    pathname: R/RE/REHSACK/List-MoreUtils-0.430.tar.gz
+    provides:
+      List::MoreUtils 0.430
+      List::MoreUtils::PP 0.430
+    requirements:
+      Exporter::Tiny 0.038
+      ExtUtils::MakeMaker 0
+      List::MoreUtils::XS 0.430
+  List-MoreUtils-XS-0.430
+    pathname: R/RE/REHSACK/List-MoreUtils-XS-0.430.tar.gz
+    provides:
+      List::MoreUtils::XS 0.430
+    requirements:
+      Carp 0
+      ExtUtils::MakeMaker 0
+      File::Basename 0
+      File::Copy 0
+      File::Path 0
+      File::Spec 0
+      IPC::Cmd 0
+      XSLoader 0.22
+      base 0
+  Log-Minimal-0.19
+    pathname: K/KA/KAZEBURO/Log-Minimal-0.19.tar.gz
+    provides:
+      Log::Minimal 0.19
+    requirements:
+      CPAN::Meta 0
+      CPAN::Meta::Prereqs 0
+      Data::Dumper 0
+      ExtUtils::CBuilder 0
+      Module::Build 0.38
+      Scalar::Util 0
+      Term::ANSIColor 0
+  MRO-Compat-0.13
+    pathname: H/HA/HAARG/MRO-Compat-0.13.tar.gz
+    provides:
+      MRO::Compat 0.13
+    requirements:
+      ExtUtils::MakeMaker 0
+      perl 5.006
+  Module-Build-0.4231
+    pathname: L/LE/LEONT/Module-Build-0.4231.tar.gz
+    provides:
+      Module::Build 0.4231
+      Module::Build::Base 0.4231
+      Module::Build::Compat 0.4231
+      Module::Build::Config 0.4231
+      Module::Build::Cookbook 0.4231
+      Module::Build::Dumper 0.4231
+      Module::Build::Notes 0.4231
+      Module::Build::PPMMaker 0.4231
+      Module::Build::Platform::Default 0.4231
+      Module::Build::Platform::MacOS 0.4231
+      Module::Build::Platform::Unix 0.4231
+      Module::Build::Platform::VMS 0.4231
+      Module::Build::Platform::VOS 0.4231
+      Module::Build::Platform::Windows 0.4231
+      Module::Build::Platform::aix 0.4231
+      Module::Build::Platform::cygwin 0.4231
+      Module::Build::Platform::darwin 0.4231
+      Module::Build::Platform::os2 0.4231
+      Module::Build::PodParser 0.4231
+    requirements:
+      CPAN::Meta 2.142060
+      Cwd 0
+      Data::Dumper 0
+      ExtUtils::CBuilder 0.27
+      ExtUtils::Install 0
+      ExtUtils::Manifest 0
+      ExtUtils::Mkbootstrap 0
+      ExtUtils::ParseXS 2.21
+      File::Basename 0
+      File::Compare 0
+      File::Copy 0
+      File::Find 0
+      File::Path 0
+      File::Spec 0.82
+      Getopt::Long 0
+      Module::Metadata 1.000002
+      Perl::OSType 1
+      Pod::Man 2.17
+      TAP::Harness 3.29
+      Text::Abbrev 0
+      Text::ParseWords 0
+      perl 5.006001
+      version 0.87
+  Module-Build-Tiny-0.039
+    pathname: L/LE/LEONT/Module-Build-Tiny-0.039.tar.gz
+    provides:
+      Module::Build::Tiny 0.039
+    requirements:
+      CPAN::Meta 0
+      DynaLoader 0
+      Exporter 5.57
+      ExtUtils::CBuilder 0
+      ExtUtils::Config 0.003
+      ExtUtils::Helpers 0.020
+      ExtUtils::Install 0
+      ExtUtils::InstallPaths 0.002
+      ExtUtils::ParseXS 0
+      File::Basename 0
+      File::Find 0
+      File::Path 0
+      File::Spec::Functions 0
+      Getopt::Long 2.36
+      JSON::PP 2
+      Pod::Man 0
+      TAP::Harness::Env 0
+      perl 5.006
+      strict 0
+      warnings 0
+  Module-Build-XSUtil-0.19
+    pathname: H/HI/HIDEAKIO/Module-Build-XSUtil-0.19.tar.gz
+    provides:
+      Module::Build::XSUtil 0.19
+    requirements:
+      Devel::CheckCompiler 0
+      Devel::PPPort 0
+      Exporter 0
+      ExtUtils::CBuilder 0
+      File::Basename 0
+      File::Path 0
+      Module::Build 0.4005
+      XSLoader 0
+      parent 0
+      perl 5.008001
+  Module-CPANfile-1.1004
+    pathname: M/MI/MIYAGAWA/Module-CPANfile-1.1004.tar.gz
+    provides:
+      Module::CPANfile 1.1004
+      Module::CPANfile::Environment undef
+      Module::CPANfile::Prereq undef
+      Module::CPANfile::Prereqs undef
+      Module::CPANfile::Requirement undef
+    requirements:
+      CPAN::Meta 2.12091
+      CPAN::Meta::Prereqs 2.12091
+      ExtUtils::MakeMaker 0
+      parent 0
+  Module-Find-0.15
+    pathname: C/CR/CRENZ/Module-Find-0.15.tar.gz
+    provides:
+      Module::Find 0.15
+    requirements:
+      ExtUtils::MakeMaker 0
+      File::Find 0
+      File::Spec 0
+      Test::More 0
+      perl 5.006001
+  Module-Implementation-0.09
+    pathname: D/DR/DROLSKY/Module-Implementation-0.09.tar.gz
+    provides:
+      Module::Implementation 0.09
+    requirements:
+      Carp 0
+      ExtUtils::MakeMaker 0
+      Module::Runtime 0.012
+      Try::Tiny 0
+      strict 0
+      warnings 0
+  Module-Runtime-0.016
+    pathname: Z/ZE/ZEFRAM/Module-Runtime-0.016.tar.gz
+    provides:
+      Module::Runtime 0.016
+    requirements:
+      Module::Build 0
+      Test::More 0.41
+      perl 5.006
+      strict 0
+      warnings 0
+  Moo-2.005004
+    pathname: H/HA/HAARG/Moo-2.005004.tar.gz
+    provides:
+      Method::Generate::Accessor undef
+      Method::Generate::BuildAll undef
+      Method::Generate::Constructor undef
+      Method::Generate::DemolishAll undef
+      Moo 2.005004
+      Moo::HandleMoose undef
+      Moo::HandleMoose::FakeConstructor undef
+      Moo::HandleMoose::FakeMetaClass undef
+      Moo::HandleMoose::_TypeMap undef
+      Moo::Object undef
+      Moo::Role 2.005004
+      Moo::_Utils undef
+      Moo::sification undef
+      oo undef
+    requirements:
+      Carp 0
+      Class::Method::Modifiers 1.10
+      Exporter 0
+      ExtUtils::MakeMaker 0
+      Role::Tiny 2.002003
+      Scalar::Util 1.00
+      Sub::Defer 2.006006
+      Sub::Quote 2.006006
+      perl 5.006
+  Mouse-v2.5.10
+    pathname: S/SK/SKAJI/Mouse-v2.5.10.tar.gz
+    provides:
+      Mouse 2.005010
+      Mouse::Exporter undef
+      Mouse::Meta::Attribute undef
+      Mouse::Meta::Class undef
+      Mouse::Meta::Method undef
+      Mouse::Meta::Method::Accessor undef
+      Mouse::Meta::Method::Constructor undef
+      Mouse::Meta::Method::Delegation undef
+      Mouse::Meta::Method::Destructor undef
+      Mouse::Meta::Module undef
+      Mouse::Meta::Role undef
+      Mouse::Meta::Role::Application undef
+      Mouse::Meta::Role::Composite undef
+      Mouse::Meta::Role::Method undef
+      Mouse::Meta::TypeConstraint undef
+      Mouse::Object undef
+      Mouse::PurePerl undef
+      Mouse::Role 2.005010
+      Mouse::Spec 2.005010
+      Mouse::TypeRegistry undef
+      Mouse::Util 2.005010
+      Mouse::Util::MetaRole undef
+      Mouse::Util::TypeConstraints undef
+      Squirrel undef
+      Squirrel::Role undef
+      Test::Mouse undef
+      ouse undef
+    requirements:
+      ExtUtils::CBuilder 0
+      Module::Build 0.4005
+      Module::Build::XSUtil 0.19
+      Scalar::Util 1.14
+      XSLoader 0.02
+      perl 5.008005
+  Net-HTTP-6.21
+    pathname: O/OA/OALDERS/Net-HTTP-6.21.tar.gz
+    provides:
+      Net::HTTP 6.21
+      Net::HTTP::Methods 6.21
+      Net::HTTP::NB 6.21
+      Net::HTTPS 6.21
+    requirements:
+      Carp 0
+      Compress::Raw::Zlib 0
+      ExtUtils::MakeMaker 0
+      IO::Socket::INET 0
+      IO::Uncompress::Gunzip 0
+      URI 0
+      base 0
+      perl 5.006002
+      strict 0
+      warnings 0
+  Number-Compare-0.03
+    pathname: R/RC/RCLAMP/Number-Compare-0.03.tar.gz
+    provides:
+      Number::Compare 0.03
+    requirements:
+      ExtUtils::MakeMaker 0
+      Test::More 0
+  POSIX-strftime-Compiler-0.44
+    pathname: K/KA/KAZEBURO/POSIX-strftime-Compiler-0.44.tar.gz
+    provides:
+      POSIX::strftime::Compiler 0.44
+    requirements:
+      Carp 0
+      Exporter 0
+      Module::Build::Tiny 0.035
+      POSIX 0
+      Time::Local 0
+      perl 5.008001
+  Package-Stash-0.39
+    pathname: E/ET/ETHER/Package-Stash-0.39.tar.gz
+    provides:
+      Package::Stash 0.39
+      Package::Stash::PP 0.39
+    requirements:
+      B 0
+      Carp 0
+      Dist::CheckConflicts 0.02
+      ExtUtils::MakeMaker 0
+      Getopt::Long 0
+      Module::Implementation 0.06
+      Package::Stash::XS 0.26
+      Scalar::Util 0
+      Symbol 0
+      Text::ParseWords 0
+      constant 0
+      perl 5.008001
+      strict 0
+      warnings 0
+  Package-Stash-XS-0.29
+    pathname: E/ET/ETHER/Package-Stash-XS-0.29.tar.gz
+    provides:
+      Package::Stash::XS 0.29
+    requirements:
+      ExtUtils::MakeMaker 0
+      XSLoader 0
+      perl 5.008001
+      strict 0
+      warnings 0
+  Parallel-Prefork-0.18
+    pathname: K/KA/KAZUHO/Parallel-Prefork-0.18.tar.gz
+    provides:
+      Parallel::Prefork 0.18
+      Parallel::Prefork::SpareWorkers undef
+      Parallel::Prefork::SpareWorkers::Scoreboard undef
+    requirements:
+      Class::Accessor::Lite 0.04
+      ExtUtils::MakeMaker 6.59
+      List::MoreUtils 0
+      Proc::Wait3 0.03
+      Scope::Guard 0
+      Signal::Mask 0
+      Test::Requires 0
+      Test::SharedFork 0
+      perl 5.008001
+  Params-Validate-1.30
+    pathname: D/DR/DROLSKY/Params-Validate-1.30.tar.gz
+    provides:
+      Params::Validate 1.30
+      Params::Validate::Constants 1.30
+      Params::Validate::PP 1.30
+      Params::Validate::XS 1.30
+    requirements:
+      Carp 0
+      Exporter 0
+      ExtUtils::CBuilder 0
+      Module::Build 0.4227
+      Module::Implementation 0
+      Scalar::Util 1.10
+      XSLoader 0
+      perl 5.008001
+      strict 0
+      vars 0
+      warnings 0
+  Params-ValidationCompiler-0.30
+    pathname: D/DR/DROLSKY/Params-ValidationCompiler-0.30.tar.gz
+    provides:
+      Params::ValidationCompiler 0.30
+      Params::ValidationCompiler::Compiler 0.30
+      Params::ValidationCompiler::Exceptions 0.30
+    requirements:
+      B 0
+      Carp 0
+      Eval::Closure 0
+      Exception::Class 0
+      Exporter 0
+      ExtUtils::MakeMaker 0
+      List::Util 1.29
+      Scalar::Util 0
+      overload 0
+      strict 0
+      warnings 0
+  Plack-1.0048
+    pathname: M/MI/MIYAGAWA/Plack-1.0048.tar.gz
+    provides:
+      HTTP::Message::PSGI undef
+      HTTP::Server::PSGI undef
+      Plack 1.0048
+      Plack::App::CGIBin undef
+      Plack::App::Cascade undef
+      Plack::App::Directory undef
+      Plack::App::File undef
+      Plack::App::PSGIBin undef
+      Plack::App::URLMap undef
+      Plack::App::WrapCGI undef
+      Plack::Builder undef
+      Plack::Component undef
+      Plack::HTTPParser undef
+      Plack::HTTPParser::PP undef
+      Plack::Handler undef
+      Plack::Handler::Apache1 undef
+      Plack::Handler::Apache2 undef
+      Plack::Handler::Apache2::Registry undef
+      Plack::Handler::CGI undef
+      Plack::Handler::CGI::Writer undef
+      Plack::Handler::FCGI undef
+      Plack::Handler::HTTP::Server::PSGI undef
+      Plack::Handler::Standalone undef
+      Plack::LWPish undef
+      Plack::Loader undef
+      Plack::Loader::Delayed undef
+      Plack::Loader::Restarter undef
+      Plack::Loader::Shotgun undef
+      Plack::MIME undef
+      Plack::Middleware undef
+      Plack::Middleware::AccessLog undef
+      Plack::Middleware::AccessLog::Timed undef
+      Plack::Middleware::Auth::Basic undef
+      Plack::Middleware::BufferedStreaming undef
+      Plack::Middleware::Chunked undef
+      Plack::Middleware::Conditional undef
+      Plack::Middleware::ConditionalGET undef
+      Plack::Middleware::ContentLength undef
+      Plack::Middleware::ContentMD5 undef
+      Plack::Middleware::ErrorDocument undef
+      Plack::Middleware::HTTPExceptions undef
+      Plack::Middleware::Head undef
+      Plack::Middleware::IIS6ScriptNameFix undef
+      Plack::Middleware::IIS7KeepAliveFix undef
+      Plack::Middleware::JSONP undef
+      Plack::Middleware::LighttpdScriptNameFix undef
+      Plack::Middleware::Lint undef
+      Plack::Middleware::Log4perl undef
+      Plack::Middleware::LogDispatch undef
+      Plack::Middleware::NullLogger undef
+      Plack::Middleware::RearrangeHeaders undef
+      Plack::Middleware::Recursive undef
+      Plack::Middleware::Refresh undef
+      Plack::Middleware::Runtime undef
+      Plack::Middleware::SimpleContentFilter undef
+      Plack::Middleware::SimpleLogger undef
+      Plack::Middleware::StackTrace undef
+      Plack::Middleware::Static undef
+      Plack::Middleware::XFramework undef
+      Plack::Middleware::XSendfile undef
+      Plack::Recursive::ForwardRequest undef
+      Plack::Request 1.0048
+      Plack::Request::Upload undef
+      Plack::Response 1.0048
+      Plack::Runner undef
+      Plack::TempBuffer undef
+      Plack::Test undef
+      Plack::Test::MockHTTP undef
+      Plack::Test::Server undef
+      Plack::Test::Suite undef
+      Plack::Util undef
+      Plack::Util::Accessor undef
+      Plack::Util::IOWithPath undef
+      Plack::Util::Prototype undef
+    requirements:
+      Apache::LogFormat::Compiler 0.33
+      Cookie::Baker 0.07
+      Devel::StackTrace 1.23
+      Devel::StackTrace::AsHTML 0.11
+      ExtUtils::MakeMaker 0
+      File::ShareDir 1.00
+      File::ShareDir::Install 0.06
+      Filesys::Notify::Simple 0
+      HTTP::Entity::Parser 0.25
+      HTTP::Headers::Fast 0.18
+      HTTP::Message 5.814
+      HTTP::Tiny 0.034
+      Hash::MultiValue 0.05
+      Pod::Usage 1.36
+      Stream::Buffered 0.02
+      Test::TCP 2.15
+      Try::Tiny 0
+      URI 1.59
+      WWW::Form::UrlEncoded 0.23
+      parent 0
+      perl 5.008001
+  Plack-Middleware-ReverseProxy-0.16
+    pathname: M/MI/MIYAGAWA/Plack-Middleware-ReverseProxy-0.16.tar.gz
+    provides:
+      Plack::Middleware::ReverseProxy 0.16
+    requirements:
+      ExtUtils::MakeMaker 6.59
+      Plack 0.9988
+      Plack::Middleware 0
+      Plack::Request 0
+      Test::More 0
+      parent 0
+      perl 5.008001
+  Plack-Middleware-Session-0.33
+    pathname: M/MI/MIYAGAWA/Plack-Middleware-Session-0.33.tar.gz
+    provides:
+      Plack::Middleware::Session 0.33
+      Plack::Middleware::Session::Cookie undef
+      Plack::Session 0.33
+      Plack::Session::Cleanup 0.33
+      Plack::Session::State 0.33
+      Plack::Session::State::Cookie 0.33
+      Plack::Session::Store 0.33
+      Plack::Session::Store::Cache 0.33
+      Plack::Session::Store::DBI 0.33
+      Plack::Session::Store::File 0.33
+      Plack::Session::Store::Null 0.33
+    requirements:
+      Cookie::Baker 0.10
+      Digest::HMAC_SHA1 1.03
+      Digest::SHA 0
+      Module::Build::Tiny 0.034
+      Plack 0.9910
+  Pod-Perldoc-3.28
+    pathname: M/MA/MALLEN/Pod-Perldoc-3.28.tar.gz
+    provides:
+      Pod::Perldoc 3.28
+      Pod::Perldoc::BaseTo 3.28
+      Pod::Perldoc::GetOptsOO 3.28
+      Pod::Perldoc::ToANSI 3.28
+      Pod::Perldoc::ToChecker 3.28
+      Pod::Perldoc::ToMan 3.28
+      Pod::Perldoc::ToNroff 3.28
+      Pod::Perldoc::ToPod 3.28
+      Pod::Perldoc::ToRtf 3.28
+      Pod::Perldoc::ToTerm 3.28
+      Pod::Perldoc::ToText 3.28
+      Pod::Perldoc::ToTk 3.28
+      Pod::Perldoc::ToXml 3.28
+    requirements:
+      Config 0
+      Encode 0
+      ExtUtils::MakeMaker 0
+      Fcntl 0
+      File::Spec::Functions 0
+      File::Temp 0.22
+      IO::Select 0
+      Pod::Man 2.18
+      Pod::Simple::RTF 3.16
+      Pod::Simple::XMLOutStream 3.16
+      Pod::Text 0
+      Symbol 0
+      Test::More 0
+      Text::ParseWords 0
+      parent 0
+      strict 0
+      warnings 0
+  Proc-Wait3-0.05
+    pathname: C/CT/CTILMES/Proc-Wait3-0.05.tar.gz
+    provides:
+      Proc::Wait3 0.05
+    requirements:
+      ExtUtils::MakeMaker 0
+  Regexp-Assemble-0.38
+    pathname: R/RS/RSAVAGE/Regexp-Assemble-0.38.tgz
+    provides:
+      Regexp::Assemble 0.38
+    requirements:
+      ExtUtils::MakeMaker 0
+      constant 0
+      strict 0
+      vars 0
+      warnings 0
+  Regexp-Common-2017060201
+    pathname: A/AB/ABIGAIL/Regexp-Common-2017060201.tar.gz
+    provides:
+      Regexp::Common 2017060201
+      Regexp::Common::CC 2017060201
+      Regexp::Common::Entry 2017060201
+      Regexp::Common::SEN 2017060201
+      Regexp::Common::URI 2017060201
+      Regexp::Common::URI::RFC1035 2017060201
+      Regexp::Common::URI::RFC1738 2017060201
+      Regexp::Common::URI::RFC1808 2017060201
+      Regexp::Common::URI::RFC2384 2017060201
+      Regexp::Common::URI::RFC2396 2017060201
+      Regexp::Common::URI::RFC2806 2017060201
+      Regexp::Common::URI::fax 2017060201
+      Regexp::Common::URI::file 2017060201
+      Regexp::Common::URI::ftp 2017060201
+      Regexp::Common::URI::gopher 2017060201
+      Regexp::Common::URI::http 2017060201
+      Regexp::Common::URI::news 2017060201
+      Regexp::Common::URI::pop 2017060201
+      Regexp::Common::URI::prospero 2017060201
+      Regexp::Common::URI::tel 2017060201
+      Regexp::Common::URI::telnet 2017060201
+      Regexp::Common::URI::tv 2017060201
+      Regexp::Common::URI::wais 2017060201
+      Regexp::Common::_support 2017060201
+      Regexp::Common::balanced 2017060201
+      Regexp::Common::comment 2017060201
+      Regexp::Common::delimited 2017060201
+      Regexp::Common::lingua 2017060201
+      Regexp::Common::list 2017060201
+      Regexp::Common::net 2017060201
+      Regexp::Common::number 2017060201
+      Regexp::Common::profanity 2017060201
+      Regexp::Common::whitespace 2017060201
+      Regexp::Common::zip 2017060201
+    requirements:
+      Config 0
+      ExtUtils::MakeMaker 0
+      perl 5.010
+      strict 0
+      vars 0
+      warnings 0
+  Role-Tiny-2.002004
+    pathname: H/HA/HAARG/Role-Tiny-2.002004.tar.gz
+    provides:
+      Role::Tiny 2.002004
+      Role::Tiny::With 2.002004
+    requirements:
+      Exporter 5.57
+      perl 5.006
+  Router-Boom-1.03
+    pathname: T/TO/TOKUHIROM/Router-Boom-1.03.tar.gz
+    provides:
+      Router::Boom 1.03
+      Router::Boom::Method 1.03
+      Router::Boom::Node undef
+    requirements:
+      Class::Accessor::Lite 0.05
+      Module::Build::Tiny 0.035
+      perl 5.008005
+  Router-Simple-0.17
+    pathname: T/TO/TOKUHIROM/Router-Simple-0.17.tar.gz
+    provides:
+      Router::Simple 0.17
+      Router::Simple::Declare undef
+      Router::Simple::Route undef
+      Router::Simple::SubMapper undef
+    requirements:
+      Class::Accessor::Lite 0.05
+      List::Util 0
+      Module::Build 0.38
+      Scalar::Util 0
+      parent 0
+      perl 5.008_001
+  Router-Simple-Sinatraish-0.03
+    pathname: T/TO/TOKUHIROM/Router-Simple-Sinatraish-0.03.tar.gz
+    provides:
+      Router::Simple::Sinatraish 0.03
+    requirements:
+      Module::Build 0.38
+      Router::Simple 0.09
+      Test::More 0.98
+      parent 0
+      perl 5.00800
+  SQL-Interp-1.27
+    pathname: Y/YO/YORHEL/SQL-Interp-1.27.tar.gz
+    provides:
+      DBIx::Interp 1.27
+      SQL::Interp 1.27
+    requirements:
+      DBI 1
+      Module::Build 0.38
+      perl v5.8.0
+  SQL-Maker-1.21
+    pathname: T/TO/TOKUHIROM/SQL-Maker-1.21.tar.gz
+    provides:
+      SQL::Maker 1.21
+      SQL::Maker::Condition undef
+      SQL::Maker::Plugin::InsertMulti undef
+      SQL::Maker::Plugin::InsertOnDuplicate undef
+      SQL::Maker::SQLType undef
+      SQL::Maker::Select undef
+      SQL::Maker::Select::Oracle undef
+      SQL::Maker::SelectSet undef
+      SQL::Maker::Util undef
+    requirements:
+      Class::Accessor::Lite 0.05
+      DBI 0
+      Module::Build::Tiny 0.035
+      Module::Load 0
+      SQL::QueryMaker 0
+      Scalar::Util 0
+      parent 0
+      perl 5.008001
+  SQL-QueryMaker-0.03
+    pathname: K/KA/KAZUHO/SQL-QueryMaker-0.03.tar.gz
+    provides:
+      SQL::QueryMaker 0.03
+    requirements:
+      DateTime 0
+      ExtUtils::MakeMaker 6.42
+      Scalar::Util 0
+      Test::More 0.98
+      Test::Requires 0
+      Tie::IxHash 0
+      perl 5.008001
+  Scalar-List-Utils-1.60
+    pathname: P/PE/PEVANS/Scalar-List-Utils-1.60.tar.gz
+    provides:
+      List::Util 1.60
+      List::Util::XS 1.60
+      Scalar::Util 1.60
+      Sub::Util 1.60
+    requirements:
+      ExtUtils::MakeMaker 0
+      perl 5.006
+  Scope-Guard-0.21
+    pathname: C/CH/CHOCOLATE/Scope-Guard-0.21.tar.gz
+    provides:
+      Scope::Guard 0.21
+    requirements:
+      ExtUtils::MakeMaker 0
+      Test::More 0
+      perl 5.006001
+  Server-Starter-0.35
+    pathname: K/KA/KAZUHO/Server-Starter-0.35.tar.gz
+    provides:
+      Server::Starter 0.35
+      Server::Starter::Guard undef
+    requirements:
+      Module::Build 0.4005
+      perl 5.008
+  Signal-Mask-0.008
+    pathname: L/LE/LEONT/Signal-Mask-0.008.tar.gz
+    provides:
+      Signal::Mask 0.008
+      Signal::Pending 0.008
+    requirements:
+      Carp 0
+      ExtUtils::MakeMaker 6.30
+      IPC::Signal 0
+      POSIX 0
+      strict 0
+      warnings 0
+  Specio-0.47
+    pathname: D/DR/DROLSKY/Specio-0.47.tar.gz
+    provides:
+      Specio 0.47
+      Specio::Coercion 0.47
+      Specio::Constraint::AnyCan 0.47
+      Specio::Constraint::AnyDoes 0.47
+      Specio::Constraint::AnyIsa 0.47
+      Specio::Constraint::Enum 0.47
+      Specio::Constraint::Intersection 0.47
+      Specio::Constraint::ObjectCan 0.47
+      Specio::Constraint::ObjectDoes 0.47
+      Specio::Constraint::ObjectIsa 0.47
+      Specio::Constraint::Parameterizable 0.47
+      Specio::Constraint::Parameterized 0.47
+      Specio::Constraint::Role::CanType 0.47
+      Specio::Constraint::Role::DoesType 0.47
+      Specio::Constraint::Role::Interface 0.47
+      Specio::Constraint::Role::IsaType 0.47
+      Specio::Constraint::Simple 0.47
+      Specio::Constraint::Structurable 0.47
+      Specio::Constraint::Structured 0.47
+      Specio::Constraint::Union 0.47
+      Specio::Declare 0.47
+      Specio::DeclaredAt 0.47
+      Specio::Exception 0.47
+      Specio::Exporter 0.47
+      Specio::Helpers 0.47
+      Specio::Library::Builtins 0.47
+      Specio::Library::Numeric 0.47
+      Specio::Library::Perl 0.47
+      Specio::Library::String 0.47
+      Specio::Library::Structured 0.47
+      Specio::Library::Structured::Dict 0.47
+      Specio::Library::Structured::Map 0.47
+      Specio::Library::Structured::Tuple 0.47
+      Specio::OO 0.47
+      Specio::PartialDump 0.47
+      Specio::Registry 0.47
+      Specio::Role::Inlinable 0.47
+      Specio::Subs 0.47
+      Specio::TypeChecks 0.47
+      Test::Specio 0.47
+    requirements:
+      B 0
+      Carp 0
+      Devel::StackTrace 0
+      Eval::Closure 0
+      Exporter 0
+      ExtUtils::MakeMaker 0
+      IO::File 0
+      List::Util 1.33
+      MRO::Compat 0
+      Module::Runtime 0
+      Role::Tiny 1.003003
+      Role::Tiny::With 0
+      Scalar::Util 0
+      Storable 0
+      Sub::Quote 0
+      Test::Fatal 0
+      Test::More 0.96
+      Try::Tiny 0
+      XString 0
+      overload 0
+      parent 0
+      perl 5.008
+      re 0
+      strict 0
+      version 0.83
+      warnings 0
+  Spiffy-0.46
+    pathname: I/IN/INGY/Spiffy-0.46.tar.gz
+    provides:
+      Spiffy 0.46
+      Spiffy::mixin undef
+    requirements:
+      ExtUtils::MakeMaker 6.30
+  Starlet-0.31
+    pathname: K/KA/KAZUHO/Starlet-0.31.tar.gz
+    provides:
+      Plack::Handler::Starlet undef
+      Starlet 0.31
+      Starlet::Server undef
+    requirements:
+      ExtUtils::MakeMaker 6.59
+      LWP::UserAgent 5.8
+      Parallel::Prefork 0.17
+      Plack 0.992
+      Server::Starter 0.06
+      Test::More 0.88
+      Test::TCP 2.1
+      perl 5.008001
+  Stream-Buffered-0.03
+    pathname: D/DO/DOY/Stream-Buffered-0.03.tar.gz
+    provides:
+      Stream::Buffered 0.03
+      Stream::Buffered::Auto undef
+      Stream::Buffered::File undef
+      Stream::Buffered::PerlIO undef
+    requirements:
+      ExtUtils::MakeMaker 6.30
+      IO::File 1.14
+  String-Diff-0.07
+    pathname: Y/YA/YAPPO/String-Diff-0.07.tar.gz
+    provides:
+      String::Diff 0.07
+    requirements:
+      Algorithm::Diff 0
+      Module::Build::Tiny 0.034
+      perl 5.008005
+  Sub-Exporter-Progressive-0.001013
+    pathname: F/FR/FREW/Sub-Exporter-Progressive-0.001013.tar.gz
+    provides:
+      A::Junk undef
+      A::JunkAll undef
+      Sub::Exporter::Progressive 0.001013
+    requirements:
+      ExtUtils::MakeMaker 0
+  Sub-Identify-0.14
+    pathname: R/RG/RGARCIA/Sub-Identify-0.14.tar.gz
+    provides:
+      Sub::Identify 0.14
+    requirements:
+      ExtUtils::MakeMaker 0
+      Test::More 0
+  Sub-Quote-2.006006
+    pathname: H/HA/HAARG/Sub-Quote-2.006006.tar.gz
+    provides:
+      Sub::Defer 2.006006
+      Sub::Quote 2.006006
+    requirements:
+      ExtUtils::MakeMaker 0
+      Scalar::Util 0
+      perl 5.006
+  Sub-Uplevel-0.2800
+    pathname: D/DA/DAGOLDEN/Sub-Uplevel-0.2800.tar.gz
+    provides:
+      Sub::Uplevel 0.2800
+    requirements:
+      Carp 0
+      ExtUtils::MakeMaker 6.17
+      constant 0
+      perl 5.006
+      strict 0
+      warnings 0
+  Test-Base-0.89
+    pathname: I/IN/INGY/Test-Base-0.89.tar.gz
+    provides:
+      Test::Base 0.89
+      Test::Base::Block 0.89
+      Test::Base::Filter undef
+      Test::Base::Handle 0.89
+    requirements:
+      ExtUtils::MakeMaker 0
+      Filter::Util::Call 0
+      Scalar::Util 1.07
+      Spiffy 0.40
+      Test::More 0.88
+      perl 5.008001
+  Test-Deep-1.130
+    pathname: R/RJ/RJBS/Test-Deep-1.130.tar.gz
+    provides:
+      Test::Deep 1.130
+      Test::Deep::All undef
+      Test::Deep::Any undef
+      Test::Deep::Array undef
+      Test::Deep::ArrayEach undef
+      Test::Deep::ArrayElementsOnly undef
+      Test::Deep::ArrayLength undef
+      Test::Deep::ArrayLengthOnly undef
+      Test::Deep::Blessed undef
+      Test::Deep::Boolean undef
+      Test::Deep::Cache undef
+      Test::Deep::Cache::Simple undef
+      Test::Deep::Class undef
+      Test::Deep::Cmp undef
+      Test::Deep::Code undef
+      Test::Deep::Hash undef
+      Test::Deep::HashEach undef
+      Test::Deep::HashElements undef
+      Test::Deep::HashKeys undef
+      Test::Deep::HashKeysOnly undef
+      Test::Deep::Ignore undef
+      Test::Deep::Isa undef
+      Test::Deep::ListMethods undef
+      Test::Deep::MM undef
+      Test::Deep::Methods undef
+      Test::Deep::NoTest undef
+      Test::Deep::None undef
+      Test::Deep::Number undef
+      Test::Deep::Obj undef
+      Test::Deep::Ref undef
+      Test::Deep::RefType undef
+      Test::Deep::Regexp undef
+      Test::Deep::RegexpMatches undef
+      Test::Deep::RegexpOnly undef
+      Test::Deep::RegexpRef undef
+      Test::Deep::RegexpRefOnly undef
+      Test::Deep::RegexpVersion undef
+      Test::Deep::ScalarRef undef
+      Test::Deep::ScalarRefOnly undef
+      Test::Deep::Set undef
+      Test::Deep::Shallow undef
+      Test::Deep::Stack undef
+      Test::Deep::String undef
+      Test::Deep::SubHash undef
+      Test::Deep::SubHashElements undef
+      Test::Deep::SubHashKeys undef
+      Test::Deep::SubHashKeysOnly undef
+      Test::Deep::SuperHash undef
+      Test::Deep::SuperHashElements undef
+      Test::Deep::SuperHashKeys undef
+      Test::Deep::SuperHashKeysOnly undef
+    requirements:
+      ExtUtils::MakeMaker 0
+      List::Util 1.09
+      Scalar::Util 1.09
+      Test::Builder 0
+  Test-Differences-0.68
+    pathname: D/DC/DCANTRELL/Test-Differences-0.68.tar.gz
+    provides:
+      Test::Differences 0.68
+    requirements:
+      Capture::Tiny 0.24
+      Data::Dumper 2.126
+      ExtUtils::MakeMaker 0
+      Test::More 0.88
+      Text::Diff 1.43
+  Test-Exception-0.43
+    pathname: E/EX/EXODIST/Test-Exception-0.43.tar.gz
+    provides:
+      Test::Exception 0.43
+    requirements:
+      Carp 0
+      Exporter 0
+      ExtUtils::MakeMaker 0
+      Sub::Uplevel 0.18
+      Test::Builder 0.7
+      Test::Builder::Tester 1.07
+      Test::Harness 2.03
+      base 0
+      perl 5.006001
+      strict 0
+      warnings 0
+  Test-Fatal-0.016
+    pathname: R/RJ/RJBS/Test-Fatal-0.016.tar.gz
+    provides:
+      Test::Fatal 0.016
+    requirements:
+      Carp 0
+      Exporter 5.57
+      ExtUtils::MakeMaker 0
+      Test::Builder 0
+      Try::Tiny 0.07
+      strict 0
+      warnings 0
+  Test-Harness-3.42
+    pathname: L/LE/LEONT/Test-Harness-3.42.tar.gz
+    provides:
+      App::Prove 3.42
+      App::Prove::State 3.42
+      App::Prove::State::Result 3.42
+      App::Prove::State::Result::Test 3.42
+      Harness::Hook undef
+      TAP::Base 3.42
+      TAP::Formatter::Base 3.42
+      TAP::Formatter::Color 3.42
+      TAP::Formatter::Console 3.42
+      TAP::Formatter::Console::ParallelSession 3.42
+      TAP::Formatter::Console::Session 3.42
+      TAP::Formatter::File 3.42
+      TAP::Formatter::File::Session 3.42
+      TAP::Formatter::Session 3.42
+      TAP::Harness 3.42
+      TAP::Harness::Env 3.42
+      TAP::Object 3.42
+      TAP::Parser 3.42
+      TAP::Parser::Aggregator 3.42
+      TAP::Parser::Grammar 3.42
+      TAP::Parser::Iterator 3.42
+      TAP::Parser::Iterator::Array 3.42
+      TAP::Parser::Iterator::Process 3.42
+      TAP::Parser::Iterator::Stream 3.42
+      TAP::Parser::IteratorFactory 3.42
+      TAP::Parser::Multiplexer 3.42
+      TAP::Parser::Result 3.42
+      TAP::Parser::Result::Bailout 3.42
+      TAP::Parser::Result::Comment 3.42
+      TAP::Parser::Result::Plan 3.42
+      TAP::Parser::Result::Pragma 3.42
+      TAP::Parser::Result::Test 3.42
+      TAP::Parser::Result::Unknown 3.42
+      TAP::Parser::Result::Version 3.42
+      TAP::Parser::Result::YAML 3.42
+      TAP::Parser::ResultFactory 3.42
+      TAP::Parser::Scheduler 3.42
+      TAP::Parser::Scheduler::Job 3.42
+      TAP::Parser::Scheduler::Spinner 3.42
+      TAP::Parser::Source 3.42
+      TAP::Parser::SourceHandler 3.42
+      TAP::Parser::SourceHandler::Executable 3.42
+      TAP::Parser::SourceHandler::File 3.42
+      TAP::Parser::SourceHandler::Handle 3.42
+      TAP::Parser::SourceHandler::Perl 3.42
+      TAP::Parser::SourceHandler::RawTAP 3.42
+      TAP::Parser::YAMLish::Reader 3.42
+      TAP::Parser::YAMLish::Writer 3.42
+      Test::Harness 3.42
+    requirements:
+      ExtUtils::MakeMaker 0
+  Test-Requires-0.11
+    pathname: T/TO/TOKUHIROM/Test-Requires-0.11.tar.gz
+    provides:
+      Test::Requires 0.11
+    requirements:
+      ExtUtils::MakeMaker 6.64
+      Test::Builder::Module 0
+      Test::More 0.47
+      perl 5.006
+  Test-SharedFork-0.35
+    pathname: E/EX/EXODIST/Test-SharedFork-0.35.tar.gz
+    provides:
+      Test::SharedFork 0.35
+      Test::SharedFork::Array undef
+      Test::SharedFork::Scalar undef
+      Test::SharedFork::Store undef
+    requirements:
+      ExtUtils::MakeMaker 6.64
+      File::Temp 0
+      Test::Builder 0.32
+      Test::Builder::Module 0
+      Test::More 0.88
+      perl 5.008_001
+  Test-TCP-2.22
+    pathname: M/MI/MIYAGAWA/Test-TCP-2.22.tar.gz
+    provides:
+      Net::EmptyPort undef
+      Test::TCP 2.22
+      Test::TCP::CheckPort undef
+    requirements:
+      ExtUtils::MakeMaker 6.64
+      IO::Socket::INET 0
+      IO::Socket::IP 0
+      Test::More 0
+      Test::SharedFork 0.29
+      Time::HiRes 0
+      perl 5.008001
+  Text-Diff-1.45
+    pathname: N/NE/NEILB/Text-Diff-1.45.tar.gz
+    provides:
+      Text::Diff 1.45
+      Text::Diff::Base 1.45
+      Text::Diff::Config 1.44
+      Text::Diff::Table 1.44
+    requirements:
+      Algorithm::Diff 1.19
+      Exporter 0
+      ExtUtils::MakeMaker 0
+      perl 5.006
+  Text-Diff-FormattedHTML-0.08
+    pathname: A/AM/AMBS/Text-Diff-FormattedHTML-0.08.tar.gz
+    provides:
+      Text::Diff::FormattedHTML 0.08
+    requirements:
+      Algorithm::Diff 1.1900
+      ExtUtils::MakeMaker 0
+      File::Slurp 0
+      String::Diff 0.04
+      Test::More 0
+  Text-Glob-0.11
+    pathname: R/RC/RCLAMP/Text-Glob-0.11.tar.gz
+    provides:
+      Text::Glob 0.11
+    requirements:
+      Exporter 0
+      ExtUtils::MakeMaker 0
+      constant 0
+      perl 5.005030
+  Text-Markdown-1.000031
+    pathname: B/BO/BOBTFISH/Text-Markdown-1.000031.tar.gz
+    provides:
+      Text::Markdown 1.000031
+    requirements:
+      Digest::MD5 0
+      Encode 0
+      ExtUtils::MakeMaker 6.42
+      FindBin 0
+      List::MoreUtils 0
+      Test::Differences 0
+      Test::Exception 0
+      Test::More 0.42
+      Text::Balanced 0
+  Text-Xslate-Bridge-TT2Like-0.00010
+    pathname: D/DM/DMAKI/Text-Xslate-Bridge-TT2Like-0.00010.tar.gz
+    provides:
+      Text::Xslate::Bridge::TT2Like 0.00010
+    requirements:
+      ExtUtils::MakeMaker 6.42
+      Scalar::Util 0
+      Text::Xslate 1.3000
+      perl 5.008001
+  Text-Xslate-v3.5.9
+    pathname: S/SK/SKAJI/Text-Xslate-v3.5.9.tar.gz
+    provides:
+      Text::Xslate 3.005009
+      Text::Xslate::Bridge undef
+      Text::Xslate::Bridge::Star undef
+      Text::Xslate::Compiler undef
+      Text::Xslate::HashWithDefault undef
+      Text::Xslate::PP 3.005009
+      Text::Xslate::PP::Method undef
+      Text::Xslate::PP::Opcode 3.005009
+      Text::Xslate::PP::State undef
+      Text::Xslate::PP::Type::Macro undef
+      Text::Xslate::PP::Type::Pair undef
+      Text::Xslate::PP::Type::Raw undef
+      Text::Xslate::Parser undef
+      Text::Xslate::Runner undef
+      Text::Xslate::Symbol undef
+      Text::Xslate::Syntax::Kolon undef
+      Text::Xslate::Syntax::Metakolon undef
+      Text::Xslate::Syntax::TTerse undef
+      Text::Xslate::Type::Raw undef
+      Text::Xslate::Util undef
+    requirements:
+      Data::MessagePack 0.38
+      Encode 2.26
+      ExtUtils::CBuilder 0
+      Module::Build 0.4005
+      Module::Build::XSUtil 0.19
+      Mouse v2.5.0
+      Scalar::Util 1.14
+      Storable 2.15
+      parent 0.221
+      perl 5.008001
+  Tie-IxHash-1.23
+    pathname: C/CH/CHORNY/Tie-IxHash-1.23.tar.gz
+    provides:
+      Tie::IxHash 1.23
+    requirements:
+      Test::More 0
+      perl 5.005
+  Time-Local-1.30
+    pathname: D/DR/DROLSKY/Time-Local-1.30.tar.gz
+    provides:
+      Time::Local 1.30
+    requirements:
+      Carp 0
+      Exporter 0
+      ExtUtils::MakeMaker 0
+      constant 0
+      parent 0
+      strict 0
+  TimeDate-2.33
+    pathname: A/AT/ATOOMIC/TimeDate-2.33.tar.gz
+    provides:
+      Date::Format 2.24
+      Date::Format::Generic 2.24
+      Date::Language 1.10
+      Date::Language::Afar 0.99
+      Date::Language::Amharic 1.00
+      Date::Language::Austrian 1.01
+      Date::Language::Brazilian 1.01
+      Date::Language::Bulgarian 1.01
+      Date::Language::Chinese 1.00
+      Date::Language::Chinese_GB 1.01
+      Date::Language::Czech 1.01
+      Date::Language::Danish 1.01
+      Date::Language::Dutch 1.02
+      Date::Language::English 1.01
+      Date::Language::Finnish 1.01
+      Date::Language::French 1.04
+      Date::Language::Gedeo 0.99
+      Date::Language::German 1.02
+      Date::Language::Greek 1.00
+      Date::Language::Hungarian 1.01
+      Date::Language::Icelandic 1.01
+      Date::Language::Italian 1.01
+      Date::Language::Norwegian 1.01
+      Date::Language::Occitan 1.04
+      Date::Language::Oromo 0.99
+      Date::Language::Romanian 1.01
+      Date::Language::Russian 1.01
+      Date::Language::Russian_cp1251 1.01
+      Date::Language::Russian_koi8r 1.01
+      Date::Language::Sidama 0.99
+      Date::Language::Somali 0.99
+      Date::Language::Spanish 1.00
+      Date::Language::Swedish 1.01
+      Date::Language::Tigrinya 1.00
+      Date::Language::TigrinyaEritrean 1.00
+      Date::Language::TigrinyaEthiopian 1.00
+      Date::Language::Turkish 1.0
+      Date::Parse 2.33
+      Time::Zone 2.24
+      TimeDate 1.21
+    requirements:
+      ExtUtils::MakeMaker 0
+  Try-Tiny-0.31
+    pathname: E/ET/ETHER/Try-Tiny-0.31.tar.gz
+    provides:
+      Try::Tiny 0.31
+    requirements:
+      Carp 0
+      Exporter 5.57
+      ExtUtils::MakeMaker 0
+      constant 0
+      perl 5.006
+      strict 0
+      warnings 0
+  Type-Tiny-1.012004
+    pathname: T/TO/TOBYINK/Type-Tiny-1.012004.tar.gz
+    provides:
+      Devel::TypeTiny::Perl56Compat 1.012004
+      Devel::TypeTiny::Perl58Compat 1.012004
+      Error::TypeTiny 1.012004
+      Error::TypeTiny::Assertion 1.012004
+      Error::TypeTiny::Compilation 1.012004
+      Error::TypeTiny::WrongNumberOfParameters 1.012004
+      Eval::TypeTiny 1.012004
+      Reply::Plugin::TypeTiny 1.012004
+      Test::TypeTiny 1.012004
+      Type::Coercion 1.012004
+      Type::Coercion::FromMoose 1.012004
+      Type::Coercion::Union 1.012004
+      Type::Library 1.012004
+      Type::Params 1.012004
+      Type::Parser 1.012004
+      Type::Registry 1.012004
+      Type::Tiny 1.012004
+      Type::Tiny::Class 1.012004
+      Type::Tiny::ConstrainedObject 1.012004
+      Type::Tiny::Duck 1.012004
+      Type::Tiny::Enum 1.012004
+      Type::Tiny::Intersection 1.012004
+      Type::Tiny::Role 1.012004
+      Type::Tiny::Union 1.012004
+      Type::Utils 1.012004
+      Types::Common::Numeric 1.012004
+      Types::Common::String 1.012004
+      Types::Standard 1.012004
+      Types::Standard::ArrayRef 1.012004
+      Types::Standard::CycleTuple 1.012004
+      Types::Standard::Dict 1.012004
+      Types::Standard::HashRef 1.012004
+      Types::Standard::Map 1.012004
+      Types::Standard::ScalarRef 1.012004
+      Types::Standard::StrMatch 1.012004
+      Types::Standard::Tied 1.012004
+      Types::Standard::Tuple 1.012004
+      Types::TypeTiny 1.012004
+    requirements:
+      Exporter::Tiny 1.000000
+      ExtUtils::MakeMaker 6.17
+      perl 5.006001
+  Types-Serialiser-1.01
+    pathname: M/ML/MLEHMANN/Types-Serialiser-1.01.tar.gz
+    provides:
+      JSON::PP::Boolean 1.01
+      Types::Serialiser 1.01
+      Types::Serialiser::BooleanBase 1.01
+      Types::Serialiser::Error 1.01
+    requirements:
+      ExtUtils::MakeMaker 0
+      common::sense 0
+  UNIVERSAL-require-0.19
+    pathname: N/NE/NEILB/UNIVERSAL-require-0.19.tar.gz
+    provides:
+      UNIVERSAL 0.19
+      UNIVERSAL::require 0.19
+    requirements:
+      Carp 0
+      ExtUtils::MakeMaker 0
+      Test::More 0.47
+      perl 5.006
+      strict 0
+      warnings 0
+  URI-5.10
+    pathname: O/OA/OALDERS/URI-5.10.tar.gz
+    provides:
+      URI 5.10
+      URI::Escape 5.10
+      URI::Heuristic 5.10
+      URI::IRI 5.10
+      URI::QueryParam 5.10
+      URI::Split 5.10
+      URI::URL 5.10
+      URI::WithBase 5.10
+      URI::data 5.10
+      URI::file 5.10
+      URI::file::Base 5.10
+      URI::file::FAT 5.10
+      URI::file::Mac 5.10
+      URI::file::OS2 5.10
+      URI::file::QNX 5.10
+      URI::file::Unix 5.10
+      URI::file::Win32 5.10
+      URI::ftp 5.10
+      URI::gopher 5.10
+      URI::http 5.10
+      URI::https 5.10
+      URI::ldap 5.10
+      URI::ldapi 5.10
+      URI::ldaps 5.10
+      URI::mailto 5.10
+      URI::mms 5.10
+      URI::news 5.10
+      URI::nntp 5.10
+      URI::nntps 5.10
+      URI::pop 5.10
+      URI::rlogin 5.10
+      URI::rsync 5.10
+      URI::rtsp 5.10
+      URI::rtspu 5.10
+      URI::sftp 5.10
+      URI::sip 5.10
+      URI::sips 5.10
+      URI::snews 5.10
+      URI::ssh 5.10
+      URI::telnet 5.10
+      URI::tn3270 5.10
+      URI::urn 5.10
+      URI::urn::isbn 5.10
+      URI::urn::oid 5.10
+    requirements:
+      Carp 0
+      Cwd 0
+      Data::Dumper 0
+      Encode 0
+      Exporter 5.57
+      ExtUtils::MakeMaker 0
+      MIME::Base64 2
+      Net::Domain 0
+      Scalar::Util 0
+      constant 0
+      integer 0
+      overload 0
+      parent 0
+      perl 5.008001
+      strict 0
+      utf8 0
+      warnings 0
+  Variable-Magic-0.62
+    pathname: V/VP/VPIT/Variable-Magic-0.62.tar.gz
+    provides:
+      Variable::Magic 0.62
+    requirements:
+      Carp 0
+      Config 0
+      Exporter 0
+      ExtUtils::MakeMaker 0
+      IO::Handle 0
+      IO::Select 0
+      IPC::Open3 0
+      POSIX 0
+      Socket 0
+      Test::More 0
+      XSLoader 0
+      base 0
+      lib 0
+      perl 5.008
+  WWW-Form-UrlEncoded-0.26
+    pathname: K/KA/KAZEBURO/WWW-Form-UrlEncoded-0.26.tar.gz
+    provides:
+      WWW::Form::UrlEncoded 0.26
+      WWW::Form::UrlEncoded::PP undef
+    requirements:
+      Exporter 0
+      Module::Build 0.4005
+      perl 5.008001
+  WWW-RobotRules-6.02
+    pathname: G/GA/GAAS/WWW-RobotRules-6.02.tar.gz
+    provides:
+      WWW::RobotRules 6.02
+      WWW::RobotRules::AnyDBM_File 6.00
+      WWW::RobotRules::InCore 6.02
+    requirements:
+      AnyDBM_File 0
+      ExtUtils::MakeMaker 0
+      Fcntl 0
+      URI 1.10
+      perl 5.008001
+  Web-Scraper-0.38
+    pathname: M/MI/MIYAGAWA/Web-Scraper-0.38.tar.gz
+    provides:
+      Web::Scraper 0.38
+      Web::Scraper::Filter undef
+      Web::Scraper::LibXML undef
+    requirements:
+      ExtUtils::MakeMaker 6.59
+      HTML::Entities 0
+      HTML::Selector::XPath 0.03
+      HTML::Tagset 0
+      HTML::TreeBuilder 3.23
+      HTML::TreeBuilder::XPath 0.08
+      LWP 5.827
+      Module::Build::Tiny 0.039
+      Scalar::Util 0
+      Test::Base 0
+      Test::More 0
+      Test::Requires 0
+      UNIVERSAL::require 0
+      URI 0
+      XML::XPathEngine 0.08
+      YAML 0
+      perl 5.008001
+  XML-Parser-2.46
+    pathname: T/TO/TODDR/XML-Parser-2.46.tar.gz
+    provides:
+      XML::Parser 2.46
+      XML::Parser::Expat 2.46
+      XML::Parser::Style::Debug undef
+      XML::Parser::Style::Objects undef
+      XML::Parser::Style::Stream undef
+      XML::Parser::Style::Subs undef
+      XML::Parser::Style::Tree undef
+    requirements:
+      ExtUtils::MakeMaker 0
+      LWP::UserAgent 0
+      perl 5.004050
+  XML-RSS-1.62
+    pathname: S/SH/SHLOMIF/XML-RSS-1.62.tar.gz
+    provides:
+      XML::RSS 1.62
+      XML::RSS::Private::Output::Base 1.62
+      XML::RSS::Private::Output::Roles::ImageDims 1.62
+      XML::RSS::Private::Output::Roles::ModulesElems 1.62
+      XML::RSS::Private::Output::V0_9 1.62
+      XML::RSS::Private::Output::V0_91 1.62
+      XML::RSS::Private::Output::V1_0 1.62
+      XML::RSS::Private::Output::V2_0 1.62
+    requirements:
+      Carp 0
+      DateTime::Format::Mail 0
+      DateTime::Format::W3CDTF 0
+      ExtUtils::MakeMaker 0
+      HTML::Entities 0
+      Module::Build 0.28
+      XML::Parser 0
+      perl 5.008
+      strict 0
+      vars 0
+      warnings 0
+  XML-XPathEngine-0.14
+    pathname: M/MI/MIROD/XML-XPathEngine-0.14.tar.gz
+    provides:
+      XML::XPathEngine 0.14
+      XML::XPathEngine::Boolean undef
+      XML::XPathEngine::Expr undef
+      XML::XPathEngine::Function undef
+      XML::XPathEngine::Literal undef
+      XML::XPathEngine::LocationPath undef
+      XML::XPathEngine::NodeSet undef
+      XML::XPathEngine::Number undef
+      XML::XPathEngine::Root undef
+      XML::XPathEngine::Step undef
+      XML::XPathEngine::Variable undef
+    requirements:
+      ExtUtils::MakeMaker 0
+      Test::More 0
+  XSLoader-0.24
+    pathname: S/SA/SAPER/XSLoader-0.24.tar.gz
+    provides:
+      XSLoader undef
+    requirements:
+      ExtUtils::MakeMaker 0
+      Test::More 0.47
+  XString-0.005
+    pathname: A/AT/ATOOMIC/XString-0.005.tar.gz
+    provides:
+      XString 0.005
+    requirements:
+      ExtUtils::MakeMaker 0
+      perl 5.008
+  YAML-1.30
+    pathname: T/TI/TINITA/YAML-1.30.tar.gz
+    provides:
+      YAML 1.30
+      YAML::Any 1.30
+      YAML::Dumper undef
+      YAML::Dumper::Base undef
+      YAML::Error undef
+      YAML::Loader undef
+      YAML::Loader::Base undef
+      YAML::Marshall undef
+      YAML::Mo undef
+      YAML::Node undef
+      YAML::Tag undef
+      YAML::Type::blessed undef
+      YAML::Type::code undef
+      YAML::Type::glob undef
+      YAML::Type::ref undef
+      YAML::Type::regexp undef
+      YAML::Type::undef undef
+      YAML::Types undef
+      YAML::Warning undef
+      yaml_mapping undef
+      yaml_scalar undef
+      yaml_sequence undef
+    requirements:
+      ExtUtils::MakeMaker 0
+      perl 5.008001
+  bareword-filehandles-0.007
+    pathname: I/IL/ILMARI/bareword-filehandles-0.007.tar.gz
+    provides:
+      bareword::filehandles 0.007
+    requirements:
+      B::Hooks::OP::Check 0
+      ExtUtils::Depends 0
+      ExtUtils::MakeMaker 0
+      Test::More 0.88
+      XSLoader 0
+      if 0
+      perl 5.008001
+      strict 0
+      warnings 0
+  common-sense-3.75
+    pathname: M/ML/MLEHMANN/common-sense-3.75.tar.gz
+    provides:
+      common::sense 3.75
+    requirements:
+      ExtUtils::MakeMaker 0
+  indirect-0.39
+    pathname: V/VP/VPIT/indirect-0.39.tar.gz
+    provides:
+      indirect 0.39
+    requirements:
+      Carp 0
+      Config 0
+      ExtUtils::MakeMaker 0
+      File::Spec 0
+      IO::Handle 0
+      IO::Select 0
+      IPC::Open3 0
+      POSIX 0
+      Socket 0
+      Test::More 0
+      XSLoader 0
+      lib 0
+      perl 5.008001
+  libwww-perl-6.60
+    pathname: O/OA/OALDERS/libwww-perl-6.60.tar.gz
+    provides:
+      LWP 6.60
+      LWP::Authen::Basic 6.60
+      LWP::Authen::Digest 6.60
+      LWP::Authen::Ntlm 6.60
+      LWP::ConnCache 6.60
+      LWP::Debug 6.60
+      LWP::Debug::TraceHTTP 6.60
+      LWP::DebugFile 6.60
+      LWP::MemberMixin 6.60
+      LWP::Protocol 6.60
+      LWP::Protocol::cpan 6.60
+      LWP::Protocol::data 6.60
+      LWP::Protocol::file 6.60
+      LWP::Protocol::ftp 6.60
+      LWP::Protocol::gopher 6.60
+      LWP::Protocol::http 6.60
+      LWP::Protocol::loopback 6.60
+      LWP::Protocol::mailto 6.60
+      LWP::Protocol::nntp 6.60
+      LWP::Protocol::nogo 6.60
+      LWP::RobotUA 6.60
+      LWP::Simple 6.60
+      LWP::UserAgent 6.60
+      libwww::perl undef
+    requirements:
+      CPAN::Meta::Requirements 2.120620
+      Digest::MD5 0
+      Encode 2.12
+      Encode::Locale 0
+      ExtUtils::MakeMaker 0
+      File::Copy 0
+      File::Listing 6
+      Getopt::Long 0
+      HTML::Entities 0
+      HTML::HeadParser 0
+      HTTP::Cookies 6
+      HTTP::Date 6
+      HTTP::Negotiate 6
+      HTTP::Request 6
+      HTTP::Request::Common 6
+      HTTP::Response 6
+      HTTP::Status 6.18
+      IO::Select 0
+      IO::Socket 0
+      LWP::MediaTypes 6
+      MIME::Base64 2.1
+      Module::Metadata 0
+      Net::FTP 2.58
+      Net::HTTP 6.18
+      Scalar::Util 0
+      Try::Tiny 0
+      URI 1.10
+      URI::Escape 0
+      WWW::RobotRules 6
+      parent 0.217
+      perl 5.008001
+      strict 0
+      warnings 0
+  multidimensional-0.014
+    pathname: I/IL/ILMARI/multidimensional-0.014.tar.gz
+    provides:
+      multidimensional 0.014
+    requirements:
+      B::Hooks::OP::Check 0.19
+      CPAN::Meta 2.112580
+      ExtUtils::Depends 0
+      ExtUtils::MakeMaker 0
+      Test::More 0.88
+      XSLoader 0
+      if 0
+      perl 5.008001
+      strict 0
+      warnings 0
+  namespace-autoclean-0.29
+    pathname: E/ET/ETHER/namespace-autoclean-0.29.tar.gz
+    provides:
+      namespace::autoclean 0.29
+    requirements:
+      B::Hooks::EndOfScope 0.12
+      ExtUtils::MakeMaker 0
+      List::Util 0
+      Sub::Identify 0
+      namespace::clean 0.20
+      perl 5.006
+      strict 0
+      warnings 0
+  namespace-clean-0.27
+    pathname: R/RI/RIBASUSHI/namespace-clean-0.27.tar.gz
+    provides:
+      namespace::clean 0.27
+    requirements:
+      B::Hooks::EndOfScope 0.12
+      ExtUtils::MakeMaker 0
+      Package::Stash 0.23
+      perl 5.008001
+  strictures-2.000006
+    pathname: H/HA/HAARG/strictures-2.000006.tar.gz
+    provides:
+      strictures 2.000006
+      strictures::extra undef
+    requirements:
+      bareword::filehandles 0
+      indirect 0
+      multidimensional 0
+      perl 5.006
+  version-0.9929
+    pathname: L/LE/LEONT/version-0.9929.tar.gz
+    provides:
+      charstar 0.9929
+      version 0.9929
+      version::regex 0.9929
+      version::vpp 0.9929
+      version::vxs 0.9929
+    requirements:
+      ExtUtils::MakeMaker 0
+      perl 5.006002

--- a/lib/PJP/Web/Dispatcher.pm
+++ b/lib/PJP/Web/Dispatcher.pm
@@ -51,16 +51,16 @@ get '/translators' => sub {
 #                                    categorized_modules => do "data/category_data.pl",
 #                                   });
 # };
-
-get '/category/:name' => sub {
-    my ($c, $args) = @_;
-    my $modules =  do "data/category_data.pl";
-    return $c->render('category/index.tt', {
-                                      en2ja    => do "data/category_en2ja.pl",
-                                      category => $args->{name},
-                                      modules  => $modules->{category_modules}->{$args->{name}},
-                                     });
-};
+# 
+# get '/category/:name' => sub {
+#     my ($c, $args) = @_;
+#     my $modules =  do "data/category_data.pl";
+#     return $c->render('category/index.tt', {
+#                                       en2ja    => do "data/category_en2ja.pl",
+#                                       category => $args->{name},
+#                                       modules  => $modules->{category_modules}->{$args->{name}},
+#                                      });
+# };
 
 get '/category/:name/:name2' => sub {
     my ($c, $args) = @_;


### PR DESCRIPTION
* .gitignore への追加 (Carton/Carmel関係、スクリプトで生成するもの)
* 新環境のcpanfile.snapshot
* `GET /category/:name` の廃止 (#20 の対応漏れ)