### PR TITLE
fix link replacing for L<C<func>|/func EXPR> format

### DIFF
--- a/lib/PJP/M/BuiltinFunction.pm
+++ b/lib/PJP/M/BuiltinFunction.pm
@@ -136,6 +136,7 @@ sub generate {
         push @functions, $name;
         my $pod = join("", "=encoding $encoding\n\n=over 4\n\n", @dynamic_pod, "\n\n=back\n");
         $pod =~ s!L</([a-z]+)>!L<$1|http://perldoc.jp/func/$1>!g;
+        $pod =~ s!L<C<([a-z]+)(>\|/\1 .+?)>!L<$1|http://perldoc.jp/func/$1>!g;
         my $html = PJP::M::Pod->pod2html(\$pod);
         $c->dbh_master->insert(
                                func => {


### PR DESCRIPTION
perlfunc 内で、`L<C<func>|/func EXPR> ` の書式が使われている際に、正しくリンクできていないのを修正しました。
`/func%20EXPR` でURLを作るべきかもですが、一旦そのままのURLで。

下記のissueに対応します。

https://github.com/jpa-perl/perldoc.jp/issues/24

