### PR TITLE
Fix some warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ db/
 /data/years.pl
 /static/docs.json
 /static/rss/
+xtc/

--- a/config/development.pl
+++ b/config/development.pl
@@ -16,7 +16,7 @@ my $slave_db  = "$ENV{HOME}/perldocjp.db";
     ],
     'Text::Xslate' => {
         path => ['tmpl/'],
-        cache => './xtc',
+        cache_dir => './xtc',
     },
     'assets_dir' => "$ENV{HOME}/assets/",
     'code_dir'   => qx/pwd/,

--- a/lib/PJP/Web.pm
+++ b/lib/PJP/Web.pm
@@ -19,7 +19,11 @@ sub create_response { shift; PJP::Web::Response->new(@_) }
 # dispatcher
 use PJP::Web::Dispatcher;
 sub dispatch {
-    return PJP::Web::Dispatcher->dispatch($_[0]) or die "response is not generated";
+    my $dispatch = PJP::Web::Dispatcher->dispatch($_[0]);
+    unless ($dispatch) {
+        die "response is not generated";
+    }
+    return  $dispatch;
 }
 
 # setup view class


### PR DESCRIPTION
次の警告の対応をしました。

- Argument "./xtc" isn't numeric in numeric ge (>=) https://github.com/jpa-perl/perldoc.jp/commit/65e74322bc6f154d41fa540509b1890a9115367d
- Possible precedence issue with control flow operator at lib/PJP/Web.pm line 22. https://github.com/jpa-perl/perldoc.jp/commit/4794960a0a53b3bf7d9acd410d61f7296ab000d6
