### PR TITLE
functions.txtはignoreしつつ、なくても動くようにする

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ db/
 /data/years.pl
 /static/docs.json
 /static/rss/
+functions.txt

--- a/lib/PJP/M/BuiltinFunction.pm
+++ b/lib/PJP/M/BuiltinFunction.pm
@@ -15,7 +15,7 @@ use PJP::Util qw/slurp/;
 # perlop から検索するものの正規表現
 my $OPS_REGEXP = 'tr|s|q|qq|y|m|qr|qx';
 
-our @FUNCTIONS = sort split /\n/, slurp(FUNCTION_LIST_FILE);
+our @FUNCTIONS = -e FUNCTION_LIST_FILE ? sort split /\n/, slurp(FUNCTION_LIST_FILE) : ();
 
 my %FUNCTIONS;
 @FUNCTIONS{@FUNCTIONS} = ();


### PR DESCRIPTION

## 問題

現在、functions.txt がない場合（リポジトリの初期状態）では、次のエラーが出ています。

```shell
% plackup -Ilib app.psgi
> Error while loading /Users/kfly8/src/github.com/kfly8/perldoc.jp/app.psgi: Cannot open file: functions.txt at lib/PJP/Util.pm line 12

% perl script/update.pl
Cannot open file: functions.txt at lib/PJP/Util.pm line 12.
```

## 原因

これは、functions.txtを、PJP::M::BuiltionFunctionのuse時にslurpしようとしているためです。
https://github.com/jpa-perl/perldoc.jp/blob/e265a519ce1c06f593f0b5c872babd860665b064/lib/PJP/M/BuiltinFunction.pm#L18

## 対応

このPRでは、functions.txt は、ignoreしつつ、functions.txtが無くても、
script/update.pl が動作し、plackupもできるようにしました。

ignoreしてもscript/update.plを動かせば、次のように関数のリストは更新されるので、運用には問題はないと思っています。

```shell
% rm functions.txt
% perl script/update.pl
% head functions.txt
lstat
getprotobyname
s
gethostbyname
getnetent
-B
tr
setprotoent
read
getnetbyaddr
```