### PR TITLE
RSSの更新が止まっていたのを修正

### DIFF
--- a/lib/PJP/M/Repository.pm
+++ b/lib/PJP/M/Repository.pm
@@ -83,6 +83,10 @@ sub _file2name {
     } elsif ($name =~ s{^(Moose[^/]*?)}{}) {
         $in = $1;
         $in =~s{-}{::};
+    } elsif ($name eq 'translation-tutorial.md') {
+        $in = '翻訳チュートリアル';
+    } elsif ($name eq 'translation_table.md') {
+        $in = '対訳表';
     } else {
         die $name;
     }


### PR DESCRIPTION
- ref. https://github.com/jpa-perl/perldoc.jp/issues/32

- RSSを生成するスクリプト(  script/create_recent.pl ) を動かしたら、対訳表と翻訳のチュートリアルのファイルと名前の対応づけができず死んでした。
  - > translation-tutorial.md at lib/PJP/M/Repository.pm line 87.

https://github.com/jpa-perl/perldoc.jp/blob/699da32ab0edfc2e5310d07e9d5a522590753aa1/lib/PJP/M/Repository.pm#L73-L88

