### PR TITLE
対訳表と翻訳チュートリアルをignoreする

### DIFF
--- a/script/create_year_data.pl
+++ b/script/create_year_data.pl
@@ -18,6 +18,8 @@ local $Data::Dumper::Terse = 1;
 
 my %IGNORE_FILES = (
     'modules/CGI-FastTemplate-1.09/README' => 1,
+    'modules/translation_table.md' => 1,
+    'modules/translation-tutorial.md' => 1,
     );
 
 main();


### PR DESCRIPTION
## 背景

script/create_year_data.pl が、次の警告を出していた。
> the path cannot be found in DB: modules/translation-tutorial.md at ./script/create_year_data.pl line 53.
> the path cannot be found in DB: modules/translation_table.md at ./script/create_year_data.pl line 53.

## 対応

- 該当ファイルを、無視対象にいれる。